### PR TITLE
Custome exceptations still not used in schema.rb

### DIFF
--- a/lib/active_resource/schema.rb
+++ b/lib/active_resource/schema.rb
@@ -1,5 +1,3 @@
-require 'active_resource/exceptions'
-
 module ActiveResource # :nodoc:
   class Schema # :nodoc:
     # attributes can be known to be one of these types. They are easy to


### PR DESCRIPTION
Custome exceptations still not used in schema.rb
