### PR TITLE
Rename known attributes

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1320,6 +1320,9 @@ module ActiveResource
               value.duplicable? ? value.dup : value
           end
       end
+      self.class.attributes_list.each do |key|
+        @attributes[key.to_s] = nil unless @attributes[key.to_s]
+      end
       self
     end
 

--- a/test/cases/base/schema_test.rb
+++ b/test/cases/base/schema_test.rb
@@ -350,6 +350,12 @@ class SchemaTest < ActiveModel::TestCase
     assert Person.new.attributes_list.blank?, "should have no known attributes on a new instance"
   end
 
+  test "new model should have attributes from class" do
+    Person.schema = {'age' => 'integer', 'name' => 'string'}
+    assert_equal Person.attributes_list.sort, ['age', 'name'].sort
+    assert_equal Person.new.attributes_list.sort, ['age', 'name'].sort
+  end
+
   test "setting schema should set known attributes on class and instance" do
     new_schema = {'age' => 'integer', 'name' => 'string',
       'height' => 'float', 'bio' => 'text',
@@ -407,11 +413,9 @@ class SchemaTest < ActiveModel::TestCase
     end
   end
 
-  test 'known attributes should be unique' do
+  test 'attributes should be unique' do
     new_schema = {'age' => 'integer', 'name' => 'string'}
     Person.schema = new_schema
-    assert_equal Person.new(:age => 20, :name => 'Matz').attributes_list, ['age', 'name']
+    assert_equal Person.new(:age => 20, :language => 'ruby').attributes_list.sort, ['age', 'name', 'language'].sort
   end
-
-
 end


### PR DESCRIPTION
I suggest to use `attributes_list` instead of `known_attributes` but with support last using `alias_method`. 

Also I think that is more correct to see attributes defined in schema in `attributes` because for now:

``` ruby
class Person < ActiveResource::Base
  self.site = "http://37s.sunrise.i:3000"
end
new_schema = {'age' => 'integer', 'name' => 'string'}
Person.schema = new_schema
Person.new.attributes
 => {} 
```

in my version it will be so:

``` ruby
class Person < ActiveResource::Base
  self.site = "http://37s.sunrise.i:3000"
end
new_schema = {'age' => 'integer', 'name' => 'string'}
Person.schema = new_schema
Person.new.attributes
 => {"age"=>nil, "name"=>nil}
```
