### PR TITLE
Adding ActiveResource::Collection

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -38,4 +38,5 @@ module ActiveResource
   autoload :Schema
   autoload :Singleton
   autoload :Validations
+  autoload :Collection
 end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -291,6 +291,7 @@ module ActiveResource
     cattr_accessor :logger
 
     class_attribute :_format
+    class_attribute :_collection_parser
 
     class << self
       # Creates a schema for this resource - setting the attributes that are
@@ -528,6 +529,16 @@ module ActiveResource
       # Returns the current format, default is ActiveResource::Formats::JsonFormat.
       def format
         self._format || ActiveResource::Formats::JsonFormat
+      end
+
+      # Sets the parser to use when a collection is returned.  The parser must be Enumerable.
+      def collection_parser=(parser_instance)
+        parser_instance = parser_instance.constantize if parser_instance.is_a?(String)
+        self._collection_parser = parser_instance
+      end
+
+      def collection_parser
+        self._collection_parser || ActiveResource::Collection
       end
 
       # Sets the number of seconds after which requests to the REST API should time out.
@@ -961,7 +972,7 @@ module ActiveResource
         end
 
         def instantiate_collection(collection, prefix_options = {})
-          collection.collect! { |record| instantiate_record(record, prefix_options) }
+          collection_parser.new(collection).collect! { |record| instantiate_record(record, prefix_options) }
         end
 
         def instantiate_record(record, prefix_options = {})

--- a/lib/active_resource/collection.rb
+++ b/lib/active_resource/collection.rb
@@ -1,0 +1,73 @@
+require 'active_support/core_ext/module/delegation'
+
+module ActiveResource # :nodoc:
+  class Collection # :nodoc:
+    include Enumerable
+    delegate :to_xml, :to_yaml, :length, :collect, :map, :each, :all?, :include?, :to_ary, :size, :last, :first, :to => :to_a
+
+    # The array of actual elements returned by index actions
+    attr_accessor :elements
+    
+    # ActiveResource::Collection is a wrapper to handle parsing index responses that
+    # do not directly map to Rails conventions.
+    #
+    # You can define a custom class that inherets from ActiveResource::Collection
+    # in order to to set the elements instance. 
+    #
+    # GET /posts.json delivers following response body:
+    #   {
+    #     posts: [
+    #       {
+    #         title: "ActiveResource now has associations",
+    #         body: "Lorem Ipsum"
+    #       }
+    #       {...}
+    #     ]
+    #     next_page: "/posts.json?page=2"
+    #   }
+    # 
+    # A Post class can be setup to handle it with:
+    #
+    #   class Post < ActiveResource::Base
+    #     self.site = "http://example.com"
+    #     self.collection_parser = PostParser
+    #   end
+    #
+    # And the collection parser:
+    #
+    #   class PostCollection < ActiveResource::Collection
+    #     attr_accessor :next_page
+    #     def initialize(parsed = {})
+    #       @elements = parsed['posts']
+    #       @next_page = parsed['next_page']
+    #     end
+    #   end
+    #
+    # The result from a find method that returns multiple entries will now be a 
+    # PostParser instance.  ActiveResource::Collection includes Enumerable and
+    # instances can be iterated over just like an array.
+    #    @posts = Post.find(:all) # => PostCollection:xxx
+    #    @posts.next_page         # => "/posts.json?page=2"
+    #    @posts.map(&:id)         # =>[1, 3, 5 ...]
+    #
+    # The initialize method will receive the ActiveResource::Formats parsed result
+    # and should set @elements.
+    def initialize(elements = [])
+      @elements = elements
+    end
+    
+    def to_a
+      elements
+    end
+    
+    def collect!
+      return elements unless block_given?
+      set = []
+      each { |o| set << yield(o) }
+      @elements = set
+      self
+    end
+    alias map! collect!
+
+  end
+end

--- a/test/cases/collection_test.rb
+++ b/test/cases/collection_test.rb
@@ -1,0 +1,68 @@
+class CollectionTest < ActiveSupport::TestCase
+  def setup
+    @collection = ActiveResource::Collection.new
+  end  
+end
+
+class BasicCollectionTest < CollectionTest
+  def test_collection_respond_to_collect!
+    assert @collection.respond_to?(:collect!)
+  end
+  def test_collection_respond_to_map!
+    assert @collection.respond_to?(:map!)
+  end
+  
+  def test_collect_bang_modifies_elements
+    elements = %w(a b c)
+    @collection.elements = elements
+    results = @collection.collect! { |i| i + "!" }
+    assert_equal results.to_a, elements.collect! { |i| i + "!" }
+  end
+  
+  def test_collect_bang_returns_collection
+    @collection.elements = %w(a)
+    results = @collection.collect! { |i| i + "!" }
+    assert_kind_of ActiveResource::Collection, results
+  end
+end
+
+class PaginatedCollection < ActiveResource::Collection
+  attr_accessor :next_page
+  def initialize(parsed = {})
+    @elements = parsed['results']
+    @next_page = parsed['next_page']
+  end
+end
+
+class PaginatedPost < ActiveResource::Base
+  self.site = 'http://37s.sunrise.i:3000'
+  self.collection_parser = 'PaginatedCollection'
+end
+
+class ReduxCollection < ActiveResource::Base
+  self.site = 'http://37s.sunrise.i:3000'
+  self.collection_parser = PaginatedCollection
+end
+
+
+class CollectionInheretanceTest < ActiveSupport::TestCase
+  def setup
+    @post = {:id => 1, :title => "Awesome"}
+    @posts_hash = {"results" => [@post], :next_page => '/paginated_posts.json?page=2'}
+    @posts = @posts_hash.to_json
+    @posts2 = {"results" => [@post.merge({:id => 2})], :next_page => nil}.to_json
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get    '/paginated_posts.json', {}, @posts
+      mock.get    '/paginated_posts.json?page=2', {}, @posts
+    end
+  end
+  
+  def test_setting_collection_parser
+    assert_kind_of PaginatedCollection, PaginatedPost.find(:all)
+  end
+  
+  def test_custom_accessor
+    assert_equal PaginatedPost.find(:all).next_page, @posts_hash[:next_page]
+  end
+
+end


### PR DESCRIPTION
a class inheriting from ActiveResource::Base can set a collection_parser
which can deal with API responses that do not match Rails conventions
closes #19
