### PR TITLE
Optionally yield the request response on find

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -797,6 +797,9 @@ module ActiveResource
       # * <tt>:from</tt> - Sets the path or custom method that resources will be fetched from.
       # * <tt>:params</tt> - Sets query and \prefix (nested URL) parameters.
       #
+      # ==== Optional Block
+      # Optionally takes a block which yields the response to the request.
+      #
       # ==== Examples
       #   Person.find(1)
       #   # => GET /people/1.json
@@ -828,6 +831,10 @@ module ActiveResource
       #   StreetAddress.find(1, :params => { :person_id => 1 })
       #   # => GET /people/1/street_addresses/1.json
       #
+      #   Person.find(:all) do |response|
+      #     response # => Response from request
+      #   end
+      #
       # == Failure or missing data
       #   A failure to find the requested object raises a ResourceNotFound
       #   exception if the find was called with an id.
@@ -840,16 +847,16 @@ module ActiveResource
       #   Person.find(:first)
       #   Person.find(:last)
       #   # => nil
-      def find(*arguments)
+      def find(*arguments, &block)
         scope   = arguments.slice!(0)
         options = arguments.slice!(0) || {}
 
         case scope
-          when :all   then find_every(options)
-          when :first then find_every(options).first
-          when :last  then find_every(options).last
-          when :one   then find_one(options)
-          else             find_single(scope, options)
+          when :all   then find_every(options, &block)
+          when :first then find_every(options, &block).first
+          when :last  then find_every(options, &block).last
+          when :one   then find_one(options, &block)
+          else             find_single(scope, options, &block)
         end
       end
 
@@ -922,7 +929,7 @@ module ActiveResource
         end
 
         # Find every resource
-        def find_every(options)
+        def find_every(options, &block)
           begin
             case from = options[:from]
             when Symbol
@@ -933,7 +940,9 @@ module ActiveResource
             else
               prefix_options, query_options = split_options(options[:params])
               path = collection_path(prefix_options, query_options)
-              instantiate_collection( (format.decode(connection.get(path, headers).body) || []), prefix_options )
+              response = connection.get(path, headers)
+              block.call(response) if block_given?
+              instantiate_collection( (format.decode(response.body) || []), prefix_options )
             end
           rescue ActiveResource::ResourceNotFound
             # Swallowing ResourceNotFound exceptions and return nil - as per

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1204,4 +1204,11 @@ class BaseTest < ActiveSupport::TestCase
     sound = Asset::Sound.find(1)
     assert_equal "Asset::Sound::Author", sound.author.class.to_s
   end
+
+  def test_response_block
+    Person.find(:all) do |response|
+      assert_kind_of ActiveResource::Response, response
+    end
+  end
+
 end


### PR DESCRIPTION
I am not sure that I even like this proposed interface, but I am hoping it will start a conversation. This pull request allows you to pass an optional block to find, which will yield the response from a given request.

Example:

``` ruby
Person.find(:all) do |response|
  response # => Response from request
end
```

(While this may not be the silver bullet, there are other options out there.)

This idea surfaced when wanting to access headers on the response. It seems ActiveResource is strangely silent on this. One can easily set default headers for a resource, but the per request options don't seem as elegant as they could be either. I think this leads to the bigger question: Is ActiveRecord trying completely abstract away the request and the response?

And now that ActiveResource has been split off from Rails, what is the current plan for ActiveResource? Or is that being discovered as we speak?

A team I am working with is trying to decide whether or not to use ActiveResource on a project. If we do use it, we are hoping to make some contributions from the work we will be doing. Clearly though, the momentum and direction of ActiveResource will have a bearing on our choice.

I'd love to hear from the community on this!
