### PR TITLE
Mark nested resources as persisted when loaded from a response.

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1038,7 +1038,7 @@ module ActiveResource
       @attributes     = {}.with_indifferent_access
       @prefix_options = {}
       @persisted = persisted
-      load(attributes)
+      load(attributes, false, persisted)
     end
 
     # Returns a \clone of the resource that hasn't been assigned an +id+ yet and
@@ -1266,7 +1266,7 @@ module ActiveResource
     #   my_branch.reload
     #   my_branch.name # => "Wilson Road"
     def reload
-      self.load(self.class.find(to_param, :params => @prefix_options).attributes)
+      self.load(self.class.find(to_param, :params => @prefix_options).attributes, false, true)
     end
 
     # A method to manually load attributes from a \hash. Recursively loads collections of
@@ -1290,7 +1290,7 @@ module ActiveResource
     #   your_supplier = Supplier.new
     #   your_supplier.load(my_attrs)
     #   your_supplier.save
-    def load(attributes, remove_root = false)
+    def load(attributes, remove_root = false, persisted = false)
       raise ArgumentError, "expected an attributes Hash, got #{attributes.inspect}" unless attributes.is_a?(Hash)
       @prefix_options, attributes = split_options(attributes)
 
@@ -1308,14 +1308,14 @@ module ActiveResource
               value.map do |attrs|
                 if attrs.is_a?(Hash)
                   resource ||= find_or_create_resource_for_collection(key)
-                  resource.new(attrs)
+                  resource.new(attrs, persisted)
                 else
                   attrs.duplicable? ? attrs.dup : attrs
                 end
               end
             when Hash
               resource = find_or_create_resource_for(key)
-              resource.new(value)
+              resource.new(value, persisted)
             else
               value.duplicable? ? value.dup : value
           end
@@ -1410,7 +1410,7 @@ module ActiveResource
         if (response_code_allows_body?(response.code) &&
             (response['Content-Length'].nil? || response['Content-Length'] != "0") &&
             !response.body.nil? && response.body.strip.size > 0)
-          load(self.class.format.decode(response.body), true)
+          load(self.class.format.decode(response.body), true, true)
           @persisted = true
         end
       end

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1146,6 +1146,19 @@ class BaseTest < ActiveSupport::TestCase
     end
   end
 
+  def test_persisted_nested_resources_from_response
+    luis = Customer.find(1)
+    luis.friends.each do |friend|
+      assert !friend.new?
+      friend.brothers.each do |brother|
+        assert !brother.new?
+        brother.children.each do |child|
+          assert !child.new?
+        end
+      end
+    end
+  end
+
   def test_parse_resource_with_given_has_one_resources
     Customer.send(:has_one, :mother, :class_name => "external/person")
     luis = Customer.find(1)


### PR DESCRIPTION
See the included regression test which shows the correct behaviour, and fails without the included fix.

Without this fix, saving nested resources results in a `create` rather than an `update`.
