### PR TITLE
Fix Errors#from_array refactor sorting the attributes keys

### DIFF
--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -15,12 +15,11 @@ module ActiveResource
       clear unless save_cache
       humanized_attributes = Hash[@base.attributes.keys.map { |attr_name| [attr_name.humanize, attr_name] }]
       messages.each do |message|
-        attr_message = humanized_attributes.keys.detect do |attr_name|
+        attr_message = humanized_attributes.keys.sort_by { |a| -a.length }.detect do |attr_name|
           if message[0, attr_name.size + 1] == "#{attr_name} "
             add humanized_attributes[attr_name], message[(attr_name.size + 1)..-1]
           end
         end
-
         self[:base] << message if attr_message.nil?
       end
     end


### PR DESCRIPTION
When ActiveResource grabs errors from an array of messages, if you have an attribute name compound, that starts like another attribute name, for example:

{:errors => {:phone => "is not valid", :phone_work => "can't be blank" }}

If phone is parsed first it's getting the error of phone_work too. 
For this reason, sorting the array of attributes by length we can fix this problem.
