### PR TITLE
Test failed 

### DIFF
--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -15,6 +15,7 @@ require 'mocha'
 
 class BaseTest < ActiveSupport::TestCase
   def setup
+    ActiveResource::Base.include_root_in_json = true
     setup_response # find me in abstract_unit
     @original_person_site = Person.site
   end


### PR DESCRIPTION
After git clone and running test I have next

```

Admins-MacBook-Pro:activeresource admin$ rake
/Users/admin/.rvm/rubies/ruby-1.9.3-p125/bin/ruby -w -I"lib:test" -I"/Users/admin/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib" "/Users/admin/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/rake_test_loader.rb" "test/**/*_test.rb" 
Run options: --seed 32545

# Running tests:

...................................................................................................................................FF...............................................................................................................................................................................................................................

Finished tests in 1.985836s, 179.2696 tests/s, 493.9985 assertions/s.

  1) Failure:
test_to_json(BaseTest) [/Users/admin/Documents/activeresource/test/cases/base_test.rb:1086]:
Expected /^\{"person":\{/ to match "{\"id\":6,\"name\":\"Joe\",\"likes_hats\":true}".

  2) Failure:
test_to_json_with_element_name(BaseTest) [/Users/admin/Documents/activeresource/test/cases/base_test.rb:1114]:
Expected /^\{"ruby_creator":\{/ to match "{\"id\":6,\"name\":\"Joe\",\"likes_hats\":true}".

356 tests, 981 assertions, 2 failures, 0 errors, 0 skips

```

I can't find where include_root_in_json = true is set 
So I added this line setup method to make tests pass.
