### PR TITLE
Flag for "include format in path"

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -291,6 +291,8 @@ module ActiveResource
 
     class_attribute :_format
     class_attribute :_collection_parser
+    class_attribute :include_format_in_path
+    self.include_format_in_path = true
 
     class << self
       # Creates a schema for this resource - setting the attributes that are
@@ -309,12 +311,12 @@ module ActiveResource
       #     schema do
       #       # define each attribute separately
       #       attribute 'name', :string
-      #   
+      #
       #       # or use the convenience methods and pass >=1 attribute names
       #       string  'eye_color', 'hair_color'
       #       integer 'age'
       #       float   'height', 'weight'
-      #   
+      #
       #       # unsupported types should be left as strings
       #       # overload the accessor methods if you need to convert them
       #       attribute 'created_at', 'string'
@@ -669,6 +671,10 @@ module ActiveResource
       alias_method :set_element_name, :element_name=  #:nodoc:
       alias_method :set_collection_name, :collection_name=  #:nodoc:
 
+      def format_extension
+        include_format_in_path ? ".#{format.extension}" : ""
+      end
+
       # Gets the element path for the given ID in +id+. If the +query_options+ parameter is omitted, Rails
       # will split from the \prefix options.
       #
@@ -699,7 +705,7 @@ module ActiveResource
         check_prefix_options(prefix_options)
 
         prefix_options, query_options = split_options(prefix_options) if query_options.nil?
-        "#{prefix(prefix_options)}#{collection_name}/#{URI.parser.escape id.to_s}.#{format.extension}#{query_string(query_options)}"
+        "#{prefix(prefix_options)}#{collection_name}/#{URI.parser.escape id.to_s}#{format_extension}#{query_string(query_options)}"
       end
 
       # Gets the new element path for REST resources.
@@ -719,7 +725,7 @@ module ActiveResource
       #   Comment.collection_path(:post_id => 5)
       #   # => /posts/5/comments/new.json
       def new_element_path(prefix_options = {})
-        "#{prefix(prefix_options)}#{collection_name}/new.#{format.extension}"
+        "#{prefix(prefix_options)}#{collection_name}/new#{format_extension}"
       end
 
       # Gets the collection path for the REST resources. If the +query_options+ parameter is omitted, Rails
@@ -746,7 +752,7 @@ module ActiveResource
       def collection_path(prefix_options = {}, query_options = nil)
         check_prefix_options(prefix_options)
         prefix_options, query_options = split_options(prefix_options) if query_options.nil?
-        "#{prefix(prefix_options)}#{collection_name}.#{format.extension}#{query_string(query_options)}"
+        "#{prefix(prefix_options)}#{collection_name}#{format_extension}#{query_string(query_options)}"
       end
 
       alias_method :set_primary_key, :primary_key=  #:nodoc:

--- a/lib/active_resource/custom_methods.rb
+++ b/lib/active_resource/custom_methods.rb
@@ -85,7 +85,7 @@ module ActiveResource
     module ClassMethods
       def custom_method_collection_url(method_name, options = {})
         prefix_options, query_options = split_options(options)
-        "#{prefix(prefix_options)}#{collection_name}/#{method_name}.#{format.extension}#{query_string(query_options)}"
+        "#{prefix(prefix_options)}#{collection_name}/#{method_name}#{format_extension}#{query_string(query_options)}"
       end
     end
 
@@ -117,11 +117,11 @@ module ActiveResource
 
     private
       def custom_method_element_url(method_name, options = {})
-        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/#{id}/#{method_name}.#{self.class.format.extension}#{self.class.__send__(:query_string, options)}"
+        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/#{id}/#{method_name}#{self.class.format_extension}#{self.class.__send__(:query_string, options)}"
       end
 
       def custom_method_new_element_url(method_name, options = {})
-        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/new/#{method_name}.#{self.class.format.extension}#{self.class.__send__(:query_string, options)}"
+        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/new/#{method_name}#{self.class.format_extension}#{self.class.__send__(:query_string, options)}"
       end
   end
 end

--- a/lib/active_resource/singleton.rb
+++ b/lib/active_resource/singleton.rb
@@ -37,7 +37,7 @@ module ActiveResource
         check_prefix_options(prefix_options)
 
         prefix_options, query_options = split_options(prefix_options) if query_options.nil?
-        "#{prefix(prefix_options)}#{singleton_name}.#{format.extension}#{query_string(query_options)}"
+        "#{prefix(prefix_options)}#{singleton_name}#{format_extension}#{query_string(query_options)}"
       end
 
       # Core method for finding singleton resources.
@@ -67,7 +67,7 @@ module ActiveResource
       private
       # Find singleton resource
       def find_singleton(options)
-        prefix_options, query_options = split_options(options[:params]) 
+        prefix_options, query_options = split_options(options[:params])
 
         path = singleton_path(prefix_options, query_options)
         resp = self.format.decode(self.connection.get(path, self.headers).body)

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1239,4 +1239,20 @@ class BaseTest < ActiveSupport::TestCase
     sound = Asset::Sound.find(1)
     assert_equal "Asset::Sound::Author", sound.author.class.to_s
   end
+
+  def test_paths_with_format
+    assert_equal "/customers.json",      Customer.collection_path
+    assert_equal "/customers/1.json",    Customer.element_path(1)
+    assert_equal "/customers/new.json",  Customer.new_element_path
+  end
+
+  def test_paths_without_format
+    ActiveResource::Base.include_format_in_path = false
+    assert_equal "/customers",      Customer.collection_path
+    assert_equal "/customers/1",    Customer.element_path(1)
+    assert_equal "/customers/new",  Customer.new_element_path
+
+  ensure
+    ActiveResource::Base.include_format_in_path = true
+  end
 end


### PR DESCRIPTION
I've added a new flag for Base class (include_format_in_path), for making the format paths configurable:

/customers

or

/customers.json
/customers.xml

Default is true, for maintaining compatibility.

See https://github.com/rails/activeresource/issues/38
