### PR TITLE
Fix nested attribute loading from anonymous classes under Ruby 1.9

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1490,7 +1490,7 @@ module ActiveResource
         if self.class.const_defined?(*const_args)
           self.class.const_get(*const_args)
         else
-          ancestors = self.class.name.split("::")
+          ancestors = self.class.name.to_s.split("::")
           if ancestors.size > 1
             find_or_create_resource_in_modules(resource_name, ancestors)
           else

--- a/test/cases/base/load_test.rb
+++ b/test/cases/base/load_test.rb
@@ -108,6 +108,12 @@ class BaseLoadTest < ActiveSupport::TestCase
     assert_equal @first_address.values.first.stringify_keys, address.attributes
   end
 
+  def test_load_one_with_unknown_resource_from_anonymous_subclass
+    subclass = Class.new(Person).tap { |c| c.element_name = 'person' }
+    address = silence_warnings { subclass.new.load(@first_address).address }
+    assert_kind_of subclass::Address, address
+  end
+
   def test_load_collection_with_existing_resource
     addresses = @person.load(@addresses_from_json).street_addresses
     assert_kind_of Array, addresses


### PR DESCRIPTION
In Ruby 1.8, anonymous classes have an empty string for a name. In Ruby 1.9, name is `nil`. This causes an error when loading nested attributes from an anonymous class as we determine its namespace. With this change, we'll stringify the name before we try to split it.

Why would you want to use anonymous classes like this? We use this pattern at 37signals to configure resource class options at runtime. For example, when requesting resources that are available at different hosts:

``` ruby
class User < ActiveResource::Base
  def self.on(account)
    Class.new(self).tap do |subclass|
      subclass.site = account.url
    end
  end
end

User.on(account).find(123)
```
