### PR TITLE
Pass the build arguments through to new_element_path.

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -766,7 +766,7 @@ module ActiveResource
       # Returns the new resource instance.
       #
       def build(attributes = {})
-        attrs = self.format.decode(connection.get("#{new_element_path}", headers).body).merge(attributes)
+        attrs = self.format.decode(connection.get("#{new_element_path(attributes)}", headers).body)
         self.new(attrs)
       end
 

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -656,6 +656,20 @@ class BaseTest < ActiveSupport::TestCase
     Person.headers.delete('key')
   end
 
+  def test_build_without_attributes_for_prefix_call
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/people/1/addresses/new.json", {}, StreetAddress.new.to_json
+    end
+    assert_raise(ActiveResource::InvalidRequestError) { StreetAddress.build }
+  end
+  
+  def test_build_with_attributes_for_prefix_call
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/people/1/addresses/new.json", {}, StreetAddress.new.to_json
+    end
+    assert_nothing_raised { StreetAddress.build(person_id: 1) }
+  end
+
   def test_save
     rick = Person.new
     assert rick.save


### PR DESCRIPTION
Failing to pass the attributes to new_element_path in the self.build method leads to bad requests for nested element paths.

For example, an api with self.site set to be

```
'foo.com/customers/:customer_id/items/:item_id'
```

will generate the url

```
/customers//items/new.json
```

when Item.build is called and the API returns an error code as a result.

If we pass the attributes from self.build through to new_element_path, this behaviour is corrected and build uses the correct url to initialise the empty ActiveResource object.

```
/customers/1/items/new.json
```
