### PR TITLE
Add an attribute check to the belongs_to resolution chain

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -126,7 +126,13 @@ module ActiveResource::Associations
     end
 
     define_method(method_name) do
-      instance_variable_defined?(ivar_name) ? instance_variable_get(ivar_name) : instance_variable_set(ivar_name, association_model.find(send(finder_key)))
+      if instance_variable_defined?(ivar_name)
+        instance_variable_get(ivar_name)
+      elsif attributes.include?(method_name)
+        attributes[method_name]
+      else
+        instance_variable_set(ivar_name, association_model.find(send(finder_key)))
+      end
     end
   end
 


### PR DESCRIPTION
Given a resource

``` ruby
class Resource < ActiveResource::Base
  belongs_to :owner
end
```

And the following JSON return

``` ruby
r = Resource.first 
=> {
  ...
  "owner": {
    ...
  }
}
```
### Current Behavior

A _NoMethodError_ is raised when trying to access the owner on the resource because the association attempts to find and use _owner_id_ which isn't present.

``` ruby
r.owner 
=> NoMethodError ...
```
### Desired Behavior

My patch makes the belongs to association behave like the others. It will look for the association name in the attributes before attempting to load it from the endpoint. Giving: 

``` ruby
r.owner 
=> #<Owner:...>
```
