### PR TITLE
Corrected the encode call to use the active formatter

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1268,7 +1268,7 @@ module ActiveResource
     # serialization format specified in ActiveResource::Base.format. The options
     # applicable depend on the configured encoding format.
     def encode(options={})
-      send("to_#{self.class.format.extension}", options)
+      self.class.format.encode(self, options)
     end
 
     # A method to \reload the attributes of this object from the remote web service.


### PR DESCRIPTION
Currently, the active resource just calls ```to_[formatter extension]``` to encode, but it should be utilizing the active formatter's encode method instead.