### PR TITLE
Ignores the attribute "_type"

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -998,7 +998,8 @@ module ActiveResource
         end
 
         def instantiate_record(record, prefix_options = {})
-          new(record, true).tap do |resource|
+          resource = (record.key? "_type") ? record["_type"].constantize : self
+          resource.new(record, true).tap do |resource|
             resource.prefix_options = prefix_options
           end
         end
@@ -1340,14 +1341,18 @@ module ActiveResource
               resource = nil
               value.map do |attrs|
                 if attrs.is_a?(Hash)
-                  resource ||= find_or_create_resource_for_collection(key)
+                  if attrs.key? "_type"
+                    resource = attrs["_type"].constantize
+                  else
+                    resource ||= find_or_create_resource_for_collection(key)
+                  end
                   resource.new(attrs, persisted)
                 else
                   attrs.duplicable? ? attrs.dup : attrs
                 end
               end
             when Hash
-              resource = find_or_create_resource_for(key)
+              resource = (value.key? "_type") ? value["_type"].constantize : find_or_create_resource_for(key)
               resource.new(value, persisted)
             else
               value.duplicable? ? value.dup : value

--- a/test/fixtures/polymorphic.rb
+++ b/test/fixtures/polymorphic.rb
@@ -1,0 +1,37 @@
+class Employee < ActiveResource::Base
+  self.site = "http://localhost:3000"
+end
+
+class Quality < ActiveResource::Base
+  self.site = "http://localhost:3000"
+end
+
+class Mood < ActiveResource::Base
+  self.site = "http://localhost:3000"
+end
+
+class Boss < Employee
+  has_one :mood
+  has_many :qualities
+end
+
+class Quality < ActiveResource::Base
+  belongs_to :employee
+end
+
+class Mood < ActiveResource::Base
+  belongs_to :employee
+end
+
+class Quality < ActiveResource::Base
+  belongs_to :employee
+end
+
+class GoodQuality < Quality
+end
+
+class BadQuality < Quality
+end
+
+class GoodMood < Mood
+end


### PR DESCRIPTION
Example:

```
#<Product:0x007fe5a4143160
 @attributes=
  {"_id"=>"5127cf107099eab6cc000004",
   "_type"=>"Medicine",
   "name"=>"Medicine Name",
   "slug"=>"medicine-slug"},
...
```