### PR TITLE
Remove errant backslash in Base documentation

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -78,7 +78,7 @@ module ActiveResource
   #
   # Since simple CRUD/life cycle methods can't accomplish every task, Active Resource also supports
   # defining your own custom REST methods. To invoke them, Active Resource provides the <tt>get</tt>,
-  # <tt>post</tt>, <tt>put</tt> and <tt>\delete</tt> methods where you can specify a custom REST method
+  # <tt>post</tt>, <tt>put</tt> and <tt>delete</tt> methods where you can specify a custom REST method
   # name to invoke.
   #
   #   # POST to the custom 'register' REST method, i.e. POST /people/new/register.json.


### PR DESCRIPTION
Noticed this in the docs while I was reading them on http://api.rubyonrails.org/classes/ActiveResource/Base.html and I decided to fix it!
