### PR TITLE
Options Class Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Active Resource 4.1.0 (unreleased) ##
+*   Fix `options[:class_name]` to keep the given class name, and not transform it to singular.
+    Example:
+
+    ```ruby
+    has_one :profile_data, class_name: 'profile_data' #will correctly use ProfileData, and not ProfileDatum
+    ```
+    Fixed and pull request available: https://github.com/rails/activeresource/pull/80
+
+    *Lucian Cancescu*
+
 ## Active Resource 4.0.0 (unreleased) ##
 
 *   No changes

--- a/lib/active_resource/reflection.rb
+++ b/lib/active_resource/reflection.rb
@@ -66,7 +66,7 @@ module ActiveResource
 
       private
       def derive_class_name
-        return (options[:class_name] ? options[:class_name].to_s : name.to_s).classify
+        return (options[:class_name] ? options[:class_name].to_s.camelize : name.to_s.classify)
       end
 
       def derive_foreign_key

--- a/test/cases/reflection_test.rb
+++ b/test/cases/reflection_test.rb
@@ -39,6 +39,11 @@ class ReflectionTest < ActiveSupport::TestCase
     assert_equal External::Person, object.klass
   end
 
+  def test_correct_class_name_matching_as_plural_string_with_namespace
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'external/profile_data'})
+    assert_equal External::ProfileData, object.klass
+  end
+
   def test_foreign_key_method_with_no_foreign_key_option
     object = ActiveResource::Reflection::AssociationReflection.new(:test, :person, {})
     assert_equal 'person_id', object.foreign_key

--- a/test/fixtures/person.rb
+++ b/test/fixtures/person.rb
@@ -6,5 +6,9 @@ module External
   class Person < ActiveResource::Base
     self.site = "http://atq.caffeine.intoxication.it"
   end
+
+  class ProfileData < ActiveResource::Base
+    self.site = "http://external.profile.data.nl"
+  end
 end
 


### PR DESCRIPTION
The class name set in options[:class_name] is currently changed to singular (by .classify).

Example with the problem:
```ruby
has_one :profile_data, class_name: 'profile_data' 
```
gives the following error:
```ruby
NameError: uninitialized constant ProfileDatum
```
I expect it to use ProfileData if that is what I specify in options[:class_name]. In this commit, if the options[:class_name] is set then that class is used, otherwise it defaults to name.to_s.classify.

So:
```ruby
has_one :profile_data, class_name: 'profile_data' #will correctly use ProfileData
```


