### PR TITLE
Only send opaque auth attribute if the server sent it with the challenge

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -269,10 +269,10 @@ module ActiveResource
             %Q(nonce="#{params['nonce']}"),
             %Q(nc="0"),
             %Q(cnonce="#{params['cnonce']}"),
-            %Q(response="#{request_digest}")].join(", ")
+            %Q(response="#{request_digest}")]
 
         auth_attrs << %Q(opaque="#{params['opaque']}") unless params['opaque'].blank?
-        auth_attrs
+        auth_attrs.join(", ")
       end
 
       def http_format_header(http_method)

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -260,16 +260,19 @@ module ActiveResource
       end
 
       def auth_attributes_for(uri, request_digest, params)
-        [
-          %Q(username="#{@user}"),
-          %Q(realm="#{params['realm']}"),
-          %Q(qop="#{params['qop']}"),
-          %Q(uri="#{uri.path}"),
-          %Q(nonce="#{params['nonce']}"),
-          %Q(nc="0"),
-          %Q(cnonce="#{params['cnonce']}"),
-          %Q(opaque="#{params['opaque']}"),
-          %Q(response="#{request_digest}")].join(", ")
+        auth_attrs = 
+          [
+            %Q(username="#{@user}"),
+            %Q(realm="#{params['realm']}"),
+            %Q(qop="#{params['qop']}"),
+            %Q(uri="#{uri.path}"),
+            %Q(nonce="#{params['nonce']}"),
+            %Q(nc="0"),
+            %Q(cnonce="#{params['cnonce']}"),
+            %Q(response="#{request_digest}")].join(", ")
+
+        auth_attrs << %Q(opaque="#{params['opaque']}") unless params['opaque'].blank?
+        auth_attrs
       end
 
       def http_format_header(http_method)

--- a/test/cases/authorization_test.rb
+++ b/test/cases/authorization_test.rb
@@ -238,11 +238,11 @@ class DigestAuthorizationTest < AuthorizationTest
 
   private
     def blank_digest_auth_header(uri, response)
-      %Q(Digest username="david", realm="", qop="", uri="#{uri}", nonce="", nc="0", cnonce="i-am-a-client-nonce", opaque="", response="#{response}")
+      %Q(Digest username="david", realm="", qop="", uri="#{uri}", nonce="", nc="0", cnonce="i-am-a-client-nonce", response="#{response}")
     end
 
     def request_digest_auth_header(uri, response)
-      %Q(Digest username="david", realm="RailsTestApp", qop="auth", uri="#{uri}", nonce="#{@nonce}", nc="0", cnonce="i-am-a-client-nonce", opaque="ef6dfb078ba22298d366f99567814ffb", response="#{response}")
+      %Q(Digest username="david", realm="RailsTestApp", qop="auth", uri="#{uri}", nonce="#{@nonce}", nc="0", cnonce="i-am-a-client-nonce", response="#{response}", opaque="ef6dfb078ba22298d366f99567814ffb")
     end
 
     def response_digest_auth_header


### PR DESCRIPTION
Apache's mod_digest will not accept a client response that includes opaque unless the server also includes opaque. By default, mod_digest does not send opaque which means ActiveResource doesn't work with mod_digest out of the box.

This change modifies auth_attributes_for to only include opaque if it was not blank.