### PR TITLE
Initialize instance with non-prefix attributes in ActiveRecord::Base.build

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -774,7 +774,7 @@ module ActiveResource
       # Returns the new resource instance.
       #
       def build(attributes = {})
-        attrs = self.format.decode(connection.get("#{new_element_path(attributes)}", headers).body)
+        attrs = self.format.decode(connection.get("#{new_element_path(attributes)}", headers).body).merge(attributes)
         self.new(attrs)
       end
 

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -717,6 +717,16 @@ class BaseTest < ActiveSupport::TestCase
     assert_nothing_raised { StreetAddress.build(person_id: 1) }
   end
 
+  def test_build_with_non_prefix_attributes
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/people/1/addresses/new.json", {}, StreetAddress.new.to_json
+    end
+    assert_nothing_raised do
+      address = StreetAddress.build(person_id: 1, city: "Toronto")
+      assert_equal "Toronto", address.city
+    end
+  end
+
   def test_save
     rick = Person.new
     assert rick.save


### PR DESCRIPTION
`ActiveResource::Base.build` used to use the attributes to initialize the instance. That functionality was lost when the attributes started to be passed to `new_element_path` (see https://github.com/rails/activeresource/commit/fd3616a46b90b10015a47b1275c1109ab836e9f3).

This PR re-adds the functionality.