### PR TITLE
Exception on 404 with .find(:first), .find(:last)

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -871,8 +871,8 @@ module ActiveResource
 
         case scope
           when :all   then find_every(options)
-          when :first then find_every(options).first
-          when :last  then find_every(options).last
+          when :first then find_every(options).to_a.first
+          when :last  then find_every(options).to_a.last
           when :one   then find_one(options)
           else             find_single(scope, options)
         end

--- a/test/cases/finder_test.rb
+++ b/test/cases/finder_test.rb
@@ -123,6 +123,13 @@ class FinderTest < ActiveSupport::TestCase
     assert_equal "David", people.first.name
   end
 
+  def test_find_first_or_last_not_found
+    ActiveResource::HttpMock.respond_to { |m| m.get "/people.json", {}, "", 404 }
+
+    assert_nothing_raised { Person.find(:first) }
+    assert_nothing_raised { Person.find(:last)  }
+  end
+
   def test_find_single_by_from
     ActiveResource::HttpMock.respond_to { |m| m.get "/companies/1/manager.json", {}, @david }
 


### PR DESCRIPTION
If a collection API returns a 404 when calling .find(:first) or .find(:last), it causes an exception. Here's my original test script:

```ruby
require "active_resource"
require "webmock"

include WebMock::API

stub_request( :any, "api.example.com/people.json" ).to_return( :status => 404 )

class Person < ActiveResource::Base
  self.site = "http://api.example.com"
end

Person.find( :one )
````

And the result:

```
activeresource-4.0.0/lib/active_resource/base.rb:874:in `find': undefined method `first' for nil:NilClass (NoMethodError)
```