### PR TITLE
Subclasses support

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -144,8 +144,10 @@ module ActiveResource::Associations
         instance_variable_get(ivar_name)
       elsif attributes.include?(method_name)
         attributes[method_name]
-      else
+      elsif !new_record?
         instance_variable_set(ivar_name, association_model.find(:all, :params => {:"#{self.class.element_name}_id" => self.id}))
+      else
+        instance_variable_set(ivar_name, self.class.collection_parser.new)
       end
     end
   end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -998,11 +998,14 @@ module ActiveResource
         end
 
         def instantiate_record(record, prefix_options = {})
-          new(record, true).tap do |resource|
+          instance_klass = self
+          if defined?(self::SUBCLASSES) && self::SUBCLASSES.include?(record["type"])
+            instance_klass = record["type"].constantize
+          end
+          instance_klass.new(record, true).tap do |resource|
             resource.prefix_options = prefix_options
           end
         end
-
 
         # Accepts a URI and creates the site URI from that.
         def create_site_uri_from(site)

--- a/test/cases/association_test.rb
+++ b/test/cases/association_test.rb
@@ -38,6 +38,12 @@ class AssociationTest < ActiveSupport::TestCase
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_many)}.count
   end
 
+  def test_has_many_on_new_record
+    Post.send(:has_many, :topics)
+    Topic.stubs(:find).returns([:unexpected_response])
+    assert_equal [], Post.new.topics.to_a
+  end
+
   def test_has_one
     External::Person.send(:has_one, :customer)
     assert_equal 1, External::Person.reflections.select{|name, reflection| reflection.macro.eql?(:has_one)}.count

--- a/test/fixtures/product.rb
+++ b/test/fixtures/product.rb
@@ -1,3 +1,4 @@
 class Product < ActiveResource::Base
   self.site = 'http://37s.sunrise.i:3000'
+  SUBCLASSES = ["SubProduct"]
 end

--- a/test/fixtures/sub_product.rb
+++ b/test/fixtures/sub_product.rb
@@ -1,0 +1,2 @@
+class SubProduct < Product
+end

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -1,6 +1,8 @@
 require 'abstract_unit'
 require 'fixtures/weather'
 require 'fixtures/inventory'
+require 'fixtures/product'
+require 'fixtures/sub_product'
 
 class SingletonTest < ActiveSupport::TestCase
   def setup_weather
@@ -57,6 +59,16 @@ class SingletonTest < ActiveSupport::TestCase
 
     path = Inventory.singleton_path({:product_id =>5}, {:sold => true})
     assert_equal '/products/5/inventory.json?sold=true', path
+  end
+
+  def test_subclass_instantiation
+    product  = { :id => 1, :type => "SubProduct" }
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get    '/products/1.json', {}, product.to_json
+    end
+    sub_product = Product.find 1
+    assert_not_nil sub_product
+    assert_equal 'SubProduct', sub_product.class.name
   end
 
   def test_find_singleton


### PR DESCRIPTION
This commit will add a subclasses support so instantiate_record will build an instance of a known subclass if 'type' option was provided among the attributes in the response from the service.
