### PR TITLE
ActiveResource::Base.format.encode is working again

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1284,7 +1284,18 @@ module ActiveResource
     # serialization format specified in ActiveResource::Base.format. The options
     # applicable depend on the configured encoding format.
     def encode(options={})
-      send("to_#{self.class.format.extension}", options)
+      case self.class.format
+        when ActiveResource::Formats::JsonFormat
+          if  include_root_in_json
+            self.class.format.encode({self.class.element_name => attributes}, options)
+          else
+            self.class.format.encode(attributes, options)
+          end
+        when ActiveResource::Formats::XmlFormat
+          self.class.format.encode(attributes, {:root => self.class.element_name}.merge(options)) 
+        else
+          self.class.format.encode(attributes, options)
+      end
     end
 
     # A method to \reload the attributes of this object from the remote web service.

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1109,7 +1109,6 @@ class BaseTest < ActiveSupport::TestCase
     Person.element_name = 'ruby_creator'
     encode = matz.encode
     xml = matz.to_xml
-
     assert_equal encode, xml
     assert xml.include?('<?xml version="1.0" encoding="UTF-8"?>')
     assert xml.include?('<ruby-creator>')
@@ -1139,6 +1138,7 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   def test_to_json
+    
     joe = Person.find(6)
     encode = joe.encode
     json = joe.to_json
@@ -1165,6 +1165,7 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   def test_to_json_with_element_name
+    Person.include_root_in_json = true
     old_elem_name = Person.element_name
     joe = Person.find(6)
     Person.element_name = 'ruby_creator'
@@ -1178,6 +1179,7 @@ class BaseTest < ActiveSupport::TestCase
     assert_match %r{\}\}$}, json
   ensure
     Person.element_name = old_elem_name
+    Person.include_root_in_json = false
   end
 
   def test_to_param_quacks_like_active_record


### PR DESCRIPTION
use format.encode instead of to_json/to_xml
