### PR TITLE
has_one fallback works when target is not a Singleton

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -67,7 +67,7 @@ module ActiveResource::Associations
   # If the response body does not contain an attribute matching the association name
   # a request is sent to a singelton path under the current resource.
   # For example, if a Product class <tt>has_one :inventory</tt> calling <tt>Product#inventory</tt>
-  # will generate a request on /product/:product_id/inventory.json.
+  # will generate a request on /products/:product_id/inventory.json.
   #
   def has_one(name, options = {})
     Builder::HasOne.build(self, name, options)
@@ -159,8 +159,10 @@ module ActiveResource::Associations
         instance_variable_get(ivar_name)
       elsif attributes.include?(method_name)
         attributes[method_name]
-      else
+      elsif association_model.respond_to?(:singleton_name)
         instance_variable_set(ivar_name, association_model.find(:params => {:"#{self.class.element_name}_id" => self.id}))
+      else
+        instance_variable_set(ivar_name, association_model.find(:one, :from => "/#{self.class.collection_name}/#{self.id}/#{method_name}#{self.class.format_extension}"))
       end
     end
   end

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1249,6 +1249,18 @@ class BaseTest < ActiveSupport::TestCase
     assert product.inventory.status == ActiveSupport::JSON.decode(@inventory)['status']
   end
 
+  def test_parse_non_singleton_resource_with_has_one_makes_get_request_on_child_route
+    accepts = { 'Accept' => 'application/json' }
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get '/posts/1.json', accepts, @post
+      mock.get '/posts/1/author.json', accepts, @matz
+    end
+
+    Post.send(:has_one, :author, class_name: 'Person')
+    post = Post.find(1)
+    assert post.author.name == ActiveSupport::JSON.decode(@matz)['person']['name']
+  end
+
   def test_with_custom_formatter
     addresses = [{ :id => "1", :street => "1 Infinite Loop", :city => "Cupertino", :state => "CA" }].to_xml(:root => :addresses)
 


### PR DESCRIPTION
As documented:

> if a Product class `has_one :inventory` calling `Product#inventory` will generate a request on /products/:product_id/inventory.json.

This was implemented in #15, but only implemented and tested for a true Singleton target. It should also work when the target model does not actually include Singleton, e.g. a Post has one Author.

Forgive me for being unfamiliar with the test suite -- I didn't immediately grok why I needed to add the `@post` mock with an explicit `Accept` header. If someone can clarify for me I'll clean up as appropriate.
