### PR TITLE
display custom error messages when raising ActiveResource errors

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -131,29 +131,29 @@ module ActiveResource
       def handle_response(response)
         case response.code.to_i
           when 301, 302, 303, 307
-            raise(Redirection.new(response))
+            raise(Redirection.new(response, response.try(:body)))
           when 200...400
             response
           when 400
-            raise(BadRequest.new(response))
+            raise(BadRequest.new(response, response.try(:body)))
           when 401
-            raise(UnauthorizedAccess.new(response))
+            raise(UnauthorizedAccess.new(response, response.try(:body)))
           when 403
-            raise(ForbiddenAccess.new(response))
+            raise(ForbiddenAccess.new(response, response.try(:body)))
           when 404
-            raise(ResourceNotFound.new(response))
+            raise(ResourceNotFound.new(response, response.try(:body)))
           when 405
-            raise(MethodNotAllowed.new(response))
+            raise(MethodNotAllowed.new(response, response.try(:body)))
           when 409
-            raise(ResourceConflict.new(response))
+            raise(ResourceConflict.new(response, response.try(:body)))
           when 410
-            raise(ResourceGone.new(response))
+            raise(ResourceGone.new(response, response.try(:body)))
           when 422
-            raise(ResourceInvalid.new(response))
+            raise(ResourceInvalid.new(response, response.try(:body)))
           when 401...500
-            raise(ClientError.new(response))
+            raise(ClientError.new(response, response.try(:body)))
           when 500...600
-            raise(ServerError.new(response))
+            raise(ServerError.new(response, response.try(:body)))
           else
             raise(ConnectionError.new(response, "Unknown response code: #{response.code}"))
         end

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -11,6 +11,7 @@ module ActiveResource
       message = "Failed."
       message << "  Response code = #{response.code}." if response.respond_to?(:code)
       message << "  Response message = #{response.message}." if response.respond_to?(:message)
+      message << "  " + @message if @message
       message
     end
   end


### PR DESCRIPTION
Custom error messages sent by the server are currently lost by the time the user sees the raised error. This pull request fixes that.