### PR TITLE
Use known_attributes instead of attributes for matching error messages

### DIFF
--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -13,7 +13,7 @@ module ActiveResource
     # or not (by passing true).
     def from_array(messages, save_cache = false)
       clear unless save_cache
-      humanized_attributes = Hash[@base.attributes.keys.map { |attr_name| [attr_name.humanize, attr_name] }]
+      humanized_attributes = Hash[@base.known_attributes.map { |attr_name| [attr_name.humanize, attr_name] }]
       messages.each do |message|
         attr_message = humanized_attributes.keys.sort_by { |a| -a.length }.detect do |attr_name|
           if message[0, attr_name.size + 1] == "#{attr_name} "
@@ -35,7 +35,7 @@ module ActiveResource
 
       messages.each do |(key,errors)|
         errors.each do |error|
-          if @base.attributes.keys.include?(key)
+          if @base.known_attributes.include?(key)
             add key, error
           elsif key == 'base'
             self[:base] << error

--- a/test/cases/base_errors_test.rb
+++ b/test/cases/base_errors_test.rb
@@ -135,7 +135,7 @@ class BaseErrorsTest < ActiveSupport::TestCase
   def invalid_user_using_format(mime_type_reference)
     previous_format = Person.format
     Person.format = mime_type_reference
-    @person = Person.new(:name => '', :age => '', :phone => '', :phone_work => '')
+    @person = Person.new(:age => '', :phone => '', :phone_work => '')
     assert_equal false, @person.save
 
     yield

--- a/test/fixtures/person.rb
+++ b/test/fixtures/person.rb
@@ -1,5 +1,8 @@
 class Person < ActiveResource::Base
   self.site = "http://37s.sunrise.i:3000"
+  schema do
+    string :name
+  end
 end
 
 module External


### PR DESCRIPTION
Enables support for errors on unassigned attributes that have been specified in the schema.
Modified tests to specify name attribute in schema, and have it not assigned rather than a blank string in tests. These tests fail if using attributes.keys in validations.rb
