### PR TITLE
Instantiate observers via Railtie, and run load hooks

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -41,3 +41,6 @@ module ActiveResource
   autoload :Validations
   autoload :Collection
 end
+
+require 'active_resource/railtie' if defined? Rails
+

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1560,4 +1560,7 @@ module ActiveResource
     include ActiveModel::Serializers::Xml
     include ActiveResource::Reflection
   end
+
+  ActiveSupport.run_load_hooks(:active_resource, Base)
 end
+

--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -10,5 +10,16 @@ module ActiveResource
         ActiveResource::Base.send "#{k}=", v
       end
     end
+
+    config.after_initialize do |app|
+      ActiveSupport.on_load(:active_resource) do
+        ActiveResource::Base.instantiate_observers
+
+        ActionDispatch::Reloader.to_prepare do
+          ActiveResource::Base.instantiate_observers
+        end
+      end
+    end
   end
 end
+


### PR DESCRIPTION
I spent some time figuring out how to cleanly use the ActiveResource observer support in a Rails app, finding surprisingly little documentation beyond `ActiveModel::Observer` itself, eventually arriving at the need for this essential boilerplate in an initializer:

``` ruby
ActiveResource::Base.observers = # ...
ActiveResource::Base.instantiate_observers
```

This change packages it up as neatly as ActiveRecord observers in Rails:

``` ruby
# In config/application.rb
config.active_resource.observers = [:post_observer, :comment_observer]
```

The Railtie instantiates observers automatically, and reloads them for each request in development just like rails-observers does for ActiveRecord.
