### PR TITLE
Example for collection parser is incorrect.

### DIFF
--- a/lib/active_resource/collection.rb
+++ b/lib/active_resource/collection.rb
@@ -31,7 +31,7 @@ module ActiveResource # :nodoc:
     #
     #   class Post < ActiveResource::Base
     #     self.site = "http://example.com"
-    #     self.collection_parser = PostParser
+    #     self.collection_parser = PostCollection
     #   end
     #
     # And the collection parser:


### PR DESCRIPTION
Either "self.collection_parser = PostParser" in the original example needs to be changed to refer to the subsequent PostCollection class (the path I chose) or the PostCollection class needs to be named PostParser. Bottom line is the class name of the class that inherits from ActiveResource::Collection needs to match the name specified as collection_parser.
