### PR TITLE
Extend threadsafety to all ActiveResource::Base class attributes

### DIFF
--- a/lib/active_resource/threadsafe_attributes.rb
+++ b/lib/active_resource/threadsafe_attributes.rb
@@ -1,0 +1,57 @@
+module ThreadsafeAttributes
+  def self.included(klass)
+    klass.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def threadsafe_attribute(*attrs)
+      attrs.each do |attr|
+        define_method attr do
+          get_threadsafe_attribute(attr)
+        end
+
+        define_method "#{attr}=" do |value|
+          set_threadsafe_attribute(attr, value)
+        end
+
+        define_method "#{attr}_defined?" do
+          threadsafe_attribute_defined?(attr)
+        end
+      end
+    end
+  end
+
+  private
+
+  def get_threadsafe_attribute(name)
+    if threadsafe_attribute_defined_by_thread?(name, Thread.current)
+      get_threadsafe_attribute_by_thread(name, Thread.current)
+    elsif threadsafe_attribute_defined_by_thread?(name, Thread.main)
+      get_threadsafe_attribute_by_thread(name, Thread.main).dup.tap do |value|
+        set_threadsafe_attribute_by_thread(name, value, Thread.current)
+      end
+    end
+  end
+
+  def set_threadsafe_attribute(name, value)
+    set_threadsafe_attribute_by_thread(name, value, Thread.current)
+  end
+
+  def threadsafe_attribute_defined?(name)
+    threadsafe_attribute_defined_by_thread?(name, Thread.current) || ((Thread.current != Thread.main) && threadsafe_attribute_defined_by_thread?(name, Thread.main))
+  end
+
+  def get_threadsafe_attribute_by_thread(name, thread)
+    thread["active.resource.#{name}.#{self.object_id}"]
+  end
+
+  def set_threadsafe_attribute_by_thread(name, value, thread)
+    thread["active.resource.#{name}.#{self.object_id}.defined"] = true
+    thread["active.resource.#{name}.#{self.object_id}"] = value
+  end
+
+  def threadsafe_attribute_defined_by_thread?(name, thread)
+    thread["active.resource.#{name}.#{self.object_id}.defined"]
+  end
+
+end

--- a/lib/active_resource/version.rb
+++ b/lib/active_resource/version.rb
@@ -3,7 +3,7 @@ module ActiveResource
     MAJOR = 4
     MINOR = 0
     TINY  = 0
-    PRE   = nil
+    PRE   = "threadsafe"
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -1,0 +1,38 @@
+class ThreadsafeAttributesTest < ActiveSupport::TestCase
+
+  class TestClass
+    include ThreadsafeAttributes
+    threadsafe_attribute :safeattr
+  end
+
+  setup do
+    @tester = TestClass.new
+  end
+
+  test "#threadsafe attributes work in a single thread" do
+    refute @tester.safeattr_defined?
+    assert_nil @tester.safeattr
+    @tester.safeattr = "a value"
+    assert @tester.safeattr_defined?
+    assert_equal "a value", @tester.safeattr
+  end
+
+  test "#threadsafe attributes inherit the value of the main thread" do
+    @tester.safeattr = "a value"
+    Thread.new do
+      assert @tester.safeattr_defined?
+      assert_equal "a value", @tester.safeattr
+    end.join
+    assert_equal "a value", @tester.safeattr
+  end
+
+  test "#changing a threadsafe attribute in a thread does not affect the main thread" do
+    @tester.safeattr = "a value"
+    Thread.new do
+      @tester.safeattr = "a new value"
+      assert_equal "a new value", @tester.safeattr
+    end.join
+    assert_equal "a value", @tester.safeattr
+  end
+
+end

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -9,7 +9,7 @@ class ThreadsafeAttributesTest < ActiveSupport::TestCase
     @tester = TestClass.new
   end
 
-  test "#threadsafe attributes work in a single thread" do
+  test "threadsafe attributes work in a single thread" do
     refute @tester.safeattr_defined?
     assert_nil @tester.safeattr
     @tester.safeattr = "a value"
@@ -17,7 +17,7 @@ class ThreadsafeAttributesTest < ActiveSupport::TestCase
     assert_equal "a value", @tester.safeattr
   end
 
-  test "#threadsafe attributes inherit the value of the main thread" do
+  test "threadsafe attributes inherit the value of the main thread" do
     @tester.safeattr = "a value"
     Thread.new do
       assert @tester.safeattr_defined?
@@ -26,13 +26,22 @@ class ThreadsafeAttributesTest < ActiveSupport::TestCase
     assert_equal "a value", @tester.safeattr
   end
 
-  test "#changing a threadsafe attribute in a thread does not affect the main thread" do
+  test "writing a threadsafe attribute in a thread does not affect the main thread" do
     @tester.safeattr = "a value"
     Thread.new do
       @tester.safeattr = "a new value"
       assert_equal "a new value", @tester.safeattr
     end.join
     assert_equal "a value", @tester.safeattr
+  end
+
+  test "modifying a threadsafe attribute in a thread does not affect the main thread" do
+    @tester.safeattr = {a: 1}
+    Thread.new do
+      @tester.safeattr[:a] = 2
+      assert_equal 2, @tester.safeattr[:a]
+    end.join
+    assert_equal 1, @tester.safeattr[:a]
   end
 
 end


### PR DESCRIPTION
## Problem 1: Thread-safety

`ActiveResource::Base` has class attributes which makes it impossible to use in a threaded environment. The values for `site`, `user`, `password` and `connection` can all collide when using multiple threads.

https://github.com/rails/activeresource/commit/99cbab7381394ae58cc8ce28de44323b2fa14da1 started to add some thread safety to ActiveResource, by storing the `headers` in a thread local variable.

## Solution

Extend the same solution from `headers` to the other class attributes: `site`, `user`, `password` and `connection`.

## Problem 2: Inheriting values of thread-safe attributes between threads

With the current threadsafe implementation of `headers`, a new thread will also have a blank value for `headers`. This could lead to unexpected behaviour. For example, a typical Rails app might configure `headers` in an initializer, then use Sidekiq to process jobs. However, none of the Sidekiq jobs would inherit the initial configuration.

```
ActiveResource::Base.headers = {'User-Agent' => 'my-app'}
Thread.new do
  ActiveResource::Base.headers
  # => nil
end.join
```

## Solution

Make new threads default their values to the main thread.

```
ActiveResource::Base.headers = {'User-Agent' => 'my-app'}
Thread.new do
  ActiveResource::Base.headers['Custom-Header'] = '1234'
  ActiveResource::Base.headers
  # => {'User-Agent' => 'my-app', 'Custom-Header' => '1234'}
end.join
ActiveResource::Base.headers = {'User-Agent' => 'my-app'}
# => {'User-Agent' => 'my-app'}
```