### PR TITLE
Initialized @proxy with nil to remove warning

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -33,7 +33,7 @@ module ActiveResource
     # attribute to the URI for the remote resource service.
     def initialize(site, format = ActiveResource::Formats::JsonFormat)
       raise ArgumentError, 'Missing site URI' unless site
-      @user = @password = nil
+      @proxy = @user = @password = nil
       self.site = site
       self.format = format
     end


### PR DESCRIPTION
Added the @proxy to the initialization to remove an annoying uninitialized instance variable warning when not using a proxy.
