### PR TITLE
Verify peer by default over SSL.

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -189,8 +189,6 @@ module ActiveResource
           if defined? @ssl_options
             http.use_ssl = true
 
-            http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-
             # All the SSL options have corresponding http settings.
             @ssl_options.each { |key, value| http.send "#{key}=", value }
           end


### PR DESCRIPTION
Activeresource should default to verifying SSL :).

Users with self signed certs can set up their own certificate paths, or pass in VERIFY_NONE themselves per the documentation.

Thanks,
