### PR TITLE
Extract #fetch_and_decode method to encapsulate logic for retrieving a resource and decoding it

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -774,7 +774,7 @@ module ActiveResource
       # Returns the new resource instance.
       #
       def build(attributes = {})
-        attrs = self.format.decode(connection.get("#{new_element_path(attributes)}", headers).body)
+        attrs = fetch_and_decode("#{new_element_path(attributes)}", headers)
         self.new(attrs)
       end
 
@@ -959,11 +959,11 @@ module ActiveResource
               instantiate_collection(get(from, options[:params]), options[:params])
             when String
               path = "#{from}#{query_string(options[:params])}"
-              instantiate_collection(format.decode(connection.get(path, headers).body) || [], options[:params])
+              instantiate_collection(fetch_and_decode(path, headers) || [], options[:params])
             else
               prefix_options, query_options = split_options(options[:params])
               path = collection_path(prefix_options, query_options)
-              instantiate_collection( (format.decode(connection.get(path, headers).body) || []), query_options, prefix_options )
+              instantiate_collection(fetch_and_decode(path, headers) || [], query_options, prefix_options )
             end
           rescue ActiveResource::ResourceNotFound
             # Swallowing ResourceNotFound exceptions and return [] - as per
@@ -979,7 +979,7 @@ module ActiveResource
             instantiate_record(get(from, options[:params]))
           when String
             path = "#{from}#{query_string(options[:params])}"
-            instantiate_record(format.decode(connection.get(path, headers).body))
+            instantiate_record(fetch_and_decode(path, headers))
           end
         end
 
@@ -987,7 +987,12 @@ module ActiveResource
         def find_single(scope, options)
           prefix_options, query_options = split_options(options[:params])
           path = element_path(scope, prefix_options, query_options)
-          instantiate_record(format.decode(connection.get(path, headers).body), prefix_options)
+          instantiate_record(fetch_and_decode(path, headers), prefix_options)
+        end
+
+        # Fetch a URL and use the current format to decode the response
+        def fetch_and_decode(path, headers)
+          format.decode(connection.get(path, headers).body)
         end
 
         def instantiate_collection(collection, original_params = {}, prefix_options = {})


### PR DESCRIPTION
I'm working on an alternative `ActiveResource::Format` to decode [LDP](http://w3.org/2012/ldp/wiki/Main_Page) RDF responses. The standard defines some HTTP headers that may contain additional information that may present themselves as attributes in the model. 

In this patch, I've extracted `#fetch_and_decode` to encapsulate the logic I'll need to override to send the response headers to the format decoder. 
