### PR TITLE
Use an association's class name provided as-is, and derive a class name from the association name using the same rules as ActiveRecord

### DIFF
--- a/lib/active_resource/reflection.rb
+++ b/lib/active_resource/reflection.rb
@@ -27,7 +27,10 @@ module ActiveResource
     class AssociationReflection
 
       def initialize(macro, name, options)
-        @macro, @name, @options = macro, name, options
+        @macro = macro
+        @name = name
+        @options =  options
+        @collection = :has_many == macro
       end
 
       # Returns the name of the macro.
@@ -56,7 +59,7 @@ module ActiveResource
       #
       # <tt>has_many :clients</tt> returns <tt>'Client'</tt>
       def class_name
-        @class_name ||= derive_class_name
+        @class_name ||= (options[:class_name] || derive_class_name).to_s
       end
 
       # Returns the foreign_key for the macro.
@@ -64,9 +67,18 @@ module ActiveResource
         @foreign_key ||= self.options[:foreign_key] || "#{self.name.to_s.downcase}_id"
       end
 
+      # Returns whether or not this association reflection is for a collection
+      # association. Returns +true+ if the +macro+ is
+      # either +has_many+, +false+ otherwise.
+      def collection?
+        @collection
+      end
+
       private
       def derive_class_name
-        return (options[:class_name] ? options[:class_name].to_s : name.to_s).classify
+        class_name = name.to_s
+        class_name = class_name.singularize if collection?
+        class_name.camelize
       end
 
       def derive_foreign_key

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1239,13 +1239,13 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   def test_parse_resource_with_given_has_one_resources
-    Customer.send(:has_one, :mother, :class_name => "external/person")
+    Customer.send(:has_one, :mother, :class_name => "External::Person")
     luis = Customer.find(1)
     assert_kind_of External::Person, luis.mother
   end
 
   def test_parse_resources_with_given_has_many_resources
-    Customer.send(:has_many, :enemies, :class_name => "external/person")
+    Customer.send(:has_many, :enemies, :class_name => "External::Person")
     luis = Customer.find(1)
     luis.enemies.each do |enemy|
       assert_kind_of External::Person, enemy

--- a/test/cases/reflection_test.rb
+++ b/test/cases/reflection_test.rb
@@ -15,8 +15,8 @@ class ReflectionTest < ActiveSupport::TestCase
   end
 
   def test_correct_class_name_matching_without_class_name
-    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {})
-    assert_equal Person, object.klass
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :customer, {})
+    assert_equal Customer, object.klass
   end
 
   def test_correct_class_name_matching_as_string
@@ -25,7 +25,7 @@ class ReflectionTest < ActiveSupport::TestCase
   end
 
   def test_correct_class_name_matching_as_symbol
-    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => :person})
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => :Person})
     assert_equal Person, object.klass
   end
 
@@ -35,7 +35,7 @@ class ReflectionTest < ActiveSupport::TestCase
   end
 
   def test_correct_class_name_matching_as_string_with_namespace
-    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'external/person'})
+    object = ActiveResource::Reflection::AssociationReflection.new(:test, :people, {:class_name => 'External::Person'})
     assert_equal External::Person, object.klass
   end
 
@@ -49,9 +49,19 @@ class ReflectionTest < ActiveSupport::TestCase
     assert_equal 'client_id', object.foreign_key
   end
 
+  def test_correct_class_name_for_collection_matching_without_class_name
+    object = ActiveResource::Reflection::AssociationReflection.new(:has_many, :people, {})
+    assert_equal Person, object.klass
+  end
+
+  def test_correct_class_name_for_collection_matching_with_class_name
+    object = ActiveResource::Reflection::AssociationReflection.new(:has_many, :people, {:class_name => 'External::Person'})
+    assert_equal External::Person, object.klass
+  end
+
   def test_creation_of_reflection
     Person.reflections = {}
-    object = Person.create_reflection(:test, :people, {})
+    object = Person.create_reflection(:has_many, :people, {})
     assert_equal ActiveResource::Reflection::AssociationReflection, object.class
     assert_equal 1, Person.reflections.count
     assert_equal Person, Person.reflections[:people].klass


### PR DESCRIPTION
I've ported the algorithm from ActiveRecord to calculate the class name for an association. Unlike the existing code:
- A provided `:class_name` will be used as-is, without singularizing, and it must match a class (e.g. "External::Person", not "external/person").
  - When deriving a class name, when one isn't provided, singularize the association name only if it is a collection.  

This is very similar to #80.
