### PR TITLE
add missing fixture 'require' statements

### DIFF
--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -9,6 +9,8 @@ require "fixtures/address"
 require "fixtures/subscription_plan"
 require "fixtures/post"
 require "fixtures/comment"
+require "fixtures/product"
+require "fixtures/inventory"
 require 'active_support/json'
 require 'active_support/core_ext/hash/conversions'
 require 'mocha/setup'


### PR DESCRIPTION
`base_test.rb` is missing two `require` statements that prevent certain tests from running outside of the full test suite.
