### PR TITLE
Fix loss of prefix_options in Singleton#find

### DIFF
--- a/lib/active_resource/singleton.rb
+++ b/lib/active_resource/singleton.rb
@@ -71,7 +71,7 @@ module ActiveResource
 
         path = singleton_path(prefix_options, query_options)
         resp = self.format.decode(self.connection.get(path, self.headers).body)
-        instantiate_record(resp, {})
+        instantiate_record(resp, prefix_options)
       end
 
     end

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -83,6 +83,7 @@ class SingletonTest < ActiveSupport::TestCase
     assert_equal 'Sold Out', inventory.status
     assert_equal 10, inventory.used
     assert_equal 10, inventory.total
+    assert_equal({:product_id => 5}, inventory.prefix_options)
   end
 
   def test_find_with_query_options


### PR DESCRIPTION
Currently in `Singleton.find_singleton` the passed in prefix options get thrown away and any returned from the server get overwritten with an empty hash. This change saves the prefix options passed to `find` to the instantiated object.
