### PR TITLE
add foreign_key: option for has_many association

### DIFF
--- a/lib/active_resource/associations/builder/has_many.rb
+++ b/lib/active_resource/associations/builder/has_many.rb
@@ -1,11 +1,12 @@
 module ActiveResource::Associations::Builder 
   class HasMany < Association
+    self.valid_options += [:foreign_key]
     self.macro = :has_many
 
     def build
       validate_options
       model.create_reflection(self.class.macro, name, options).tap do |reflection|
-        model.defines_has_many_finder_method(reflection.name, reflection.klass)
+        model.defines_has_many_finder_method(reflection.name, reflection.klass, reflection.foreign_key)
       end
     end
   end


### PR DESCRIPTION
This pull request will add foreign_key: option for has_many: association, which
will provide customized foreign key name feature as belongs_to does.

An issue already been created at here: https://github.com/rails/activeresource/issues/99
