### PR TITLE
ActiveResource::Base#exists? now returns true for 200..206 response codes

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -935,7 +935,7 @@ module ActiveResource
           prefix_options, query_options = split_options(options[:params])
           path = element_path(id, prefix_options, query_options)
           response = connection.head(path, headers)
-          response.code.to_i == 200
+          (200..206).include? response.code
         end
         # id && !find_single(id, options).nil?
       rescue ActiveResource::ResourceNotFound, ActiveResource::ResourceGone

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1090,6 +1090,16 @@ class BaseTest < ActiveSupport::TestCase
     assert !Person.exists?(1)
   end
 
+  def test_exists_with_204_no_content
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.head "/people/1.json", {}, nil, 204
+    end
+
+    assert Person.exists?(1)
+  end
+
+
+
   def test_to_xml
     Person.format = :xml
     matz = Person.find(1)


### PR DESCRIPTION
Encountered this issue when my API returned a 204 for the HEAD request ActiveResource::Base#exists? sends. 
This PR adds support for the other 2xx response codes which should all indicate that the record does in fact exist.