### PR TITLE
Create gem

### DIFF
--- a/activeresource-threadsafe.gemspec
+++ b/activeresource-threadsafe.gemspec
@@ -3,7 +3,7 @@ require 'active_resource/version'
 
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
-  s.name        = 'activeresource'
+  s.name        = 'activeresource-threadsafe'
   s.version     = ActiveResource::VERSION::STRING
   s.summary     = 'REST modeling framework (part of Rails).'
   s.description = 'REST on Rails. Wrap your RESTful web app with Ruby classes and work with them like Active Record models.'

--- a/lib/active_resource/version.rb
+++ b/lib/active_resource/version.rb
@@ -1,9 +1,12 @@
 module ActiveResource
   module VERSION #:nodoc:
+    # keeping this in lockstep with Rails version numbers
     MAJOR = 4
-    MINOR = 0
+    MINOR = 2
     TINY  = 0
-    PRE   = nil
+
+    # the PRE string is used to detect that we're using threadsafe in other gems
+    PRE  = 'threadsafe'
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end


### PR DESCRIPTION
@csaunders @jamesmacauley @benjicox

Okay, so now my plan is to create a new gem, called "activeresource-threadsafe", that replaces ActiveResource. In general, it will track activeresource master, but include the threadsafe patch.

Now my question is what to do about version strings. Ideally, I could track activeresource version numbers. However, activeresource is on version 4.0.0, and hasn't released a new gem in a couple years.

So my plan is to track Rails version numbers; with each new release of Rails, I can grab the latest from master activeresource, make sure it applies cleanly over the threadsafe patches, and then release a gem with a version matching Rails.

Thoughts?