### PR TITLE
`where` for `ActiveResource::Collection`

### DIFF
--- a/lib/active_resource/collection.rb
+++ b/lib/active_resource/collection.rb
@@ -81,5 +81,11 @@ module ActiveResource # :nodoc:
     rescue NoMethodError
       raise "Cannot build resource from resource type: #{resource_class.inspect}"
     end
+
+    def where(clauses = {})
+      raise ArgumentError, "expected a clauses Hash, got #{clauses.inspect}" unless clauses.is_a? Hash
+      new_clauses = original_params.merge(clauses)
+      resource_class.where(new_clauses)
+    end
   end
 end

--- a/test/cases/collection_test.rb
+++ b/test/cases/collection_test.rb
@@ -41,6 +41,11 @@ class BasicCollectionTest < CollectionTest
     results = @collection.collect! { |i| i + "!" }
     assert_kind_of ActiveResource::Collection, results
   end
+
+  def respond_to_where
+    assert @collection.respond_to?(:where)
+  end
+
 end
 
 class PaginatedCollection < ActiveResource::Collection
@@ -76,6 +81,7 @@ class CollectionInheretanceTest < ActiveSupport::TestCase
       mock.get    '/paginated_posts/new.json', {}, @new_post
       mock.get    '/paginated_posts.json?page=2', {}, @posts
       mock.get    '/paginated_posts.json?title=test', {}, @empty_posts
+      mock.get    '/paginated_posts.json?page=2&title=Awesome', {}, @posts
       mock.post   '/paginated_posts.json', {}, nil
     end
   end
@@ -105,4 +111,11 @@ class CollectionInheretanceTest < ActiveSupport::TestCase
     post = PaginatedPost.where(:title => 'test').first_or_initialize
     assert post.valid?
   end
+
+  def test_where
+    posts = PaginatedPost.where(:page => 2)
+    next_posts = posts.where(:title => 'Awesome')
+    assert_kind_of PaginatedCollection, next_posts
+  end
+
 end


### PR DESCRIPTION
Add `where` to activeresource collection.
In activerecord you can call `where` on `ActiveRecord::Collection`, kind
of similar functionality for activeresource.

```
resources  = ActiveresourceClass.where(column_a: 'a')
resources.where(column_b: 'b') #should call resources with `column_a=a&column_b=b`, currently does not works
```
