### PR TITLE
Fix one of test order dependents

### DIFF
--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -19,11 +19,13 @@ class BaseTest < ActiveSupport::TestCase
   def setup
     ActiveResource::Base.include_root_in_json = true
     setup_response # find me in abstract_unit
-    @original_person_site = Person.site
+    @original_person_site  = Person.site
+    @original_person_proxy = Person.proxy
   end
 
   def teardown
-    Person.site = @original_person_site
+    Person.site  = @original_person_site
+    Person.proxy = @original_person_proxy
   end
 
   ########################################################################
@@ -205,6 +207,8 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   def test_proxy_reader_uses_superclass_site_until_written
+    Person.proxy = 'http://localhost'
+
     # Superclass is Object so returns nil.
     assert_nil ActiveResource::Base.proxy
     assert_nil Class.new(ActiveResource::Base).proxy


### PR DESCRIPTION
`test_proxy_reader_uses_superclass_site_until_written` fails on `assert actor.proxy.frozen?` if `Person.proxy` is not set (`proxy` returns `nil` when `superclass.proxy` is `nil`).

In case ex: `test_proxy_accessor_accepts_uri_or_string_argument` is called before `test_proxy_reader_uses_superclass_site_until_written` is called, `Person.proxy` is set to `'http://localhost'` and test is passed. But this creates order dependecy.

This PR makes sure `Person.proxy` is set in `test_proxy_reader_uses_superclass_site_until_written` test.