### PR TITLE
Fix one of test order dependents

### DIFF
--- a/test/cases/base/custom_methods_test.rb
+++ b/test/cases/base/custom_methods_test.rb
@@ -80,6 +80,9 @@ class CustomMethodsTest < ActiveSupport::TestCase
   end
 
   def test_custom_new_element_method
+    original_include_root_in_json = ActiveResource::Base.include_root_in_json
+    ActiveResource::Base.include_root_in_json = true
+
     # Test POST against a new element URL
     ryan = Person.new(:name => 'Ryan')
     assert_equal ActiveResource::Response.new(@ryan, 201, { 'Location' => '/people/5.json' }), ryan.post(:register)
@@ -94,6 +97,8 @@ class CustomMethodsTest < ActiveSupport::TestCase
 
     matz = Person.find(1)
     assert_equal ActiveResource::Response.new(@matz, 201), matz.post(:register)
+  ensure
+    ActiveResource::Base.include_root_in_json = original_include_root_in_json
   end
 
   def test_find_custom_resources


### PR DESCRIPTION
`test_custom_new_element_method` requires `include_root_in_json` is set to `true`. If not, request body is `{ :name => 'Ryan' }.to_json` and expected request body is  `{ :person => { :name => 'Ryan' } }.to_json`, so test fails.

`ActiveResource::Base.include_root_in_json` is set to `true` in `setup` on base_test.rb and test is passed. But this creates order dependecy.

This PR makes sure `ActiveResource::Base.include_root_in_json` is set to `true` in `test_custom_new_element_method`.