### PR TITLE
Specify arel in the development bundle for compatibility with edge rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', github: 'rails/rails'
+gem 'arel', github: 'rails/arel'
 gem 'rails-observers', github: 'rails/rails-observers'
 
 gemspec


### PR DESCRIPTION
Specify arel in the development bundle for compatibility with edge rails. Fixes the following error when bundling for development:

```
Could not find gem 'arel (= 7.0.0.alpha) ruby', which is required by
gem 'rails (>= 0) ruby', in any of the sources.
```
