### PR TITLE
Fix order-dependent test failures

### DIFF
--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -13,6 +13,7 @@ require 'active_support/logger'
 
 ActiveSupport::TestCase.test_order = :random if ActiveSupport::TestCase.respond_to?(:test_order=)
 ActiveResource::Base.logger = ActiveSupport::Logger.new("#{File.dirname(__FILE__)}/debug.log")
+ActiveResource::Base.include_root_in_json = true
 
 def setup_response
   matz_hash = { 'person' => { :id => 1, :name => 'Matz' } }

--- a/test/cases/base_errors_test.rb
+++ b/test/cases/base_errors_test.rb
@@ -142,6 +142,8 @@ class BaseErrorsTest < ActiveSupport::TestCase
   private
   def invalid_user_using_format(mime_type_reference)
     previous_format = Person.format
+    previous_schema = Person.schema
+
     Person.format = mime_type_reference
     Person.schema = { 'known_attribute' => 'string' }
     @person = Person.new(:name => '', :age => '', :phone => '', :phone_work => '')
@@ -150,5 +152,6 @@ class BaseErrorsTest < ActiveSupport::TestCase
     yield
   ensure
     Person.format = previous_format
+    Person.schema = previous_schema
   end
 end

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -19,10 +19,12 @@ class BaseTest < ActiveSupport::TestCase
   def setup
     setup_response # find me in abstract_unit
     @original_person_site = Person.site
+    @original_person_proxy = Person.proxy
   end
 
   def teardown
     Person.site = @original_person_site
+    Person.proxy = @original_person_proxy
   end
 
   ########################################################################
@@ -207,6 +209,8 @@ class BaseTest < ActiveSupport::TestCase
     # Superclass is Object so returns nil.
     assert_nil ActiveResource::Base.proxy
     assert_nil Class.new(ActiveResource::Base).proxy
+
+    Person.proxy = 'http://proxy.local'
 
     # Subclass uses superclass proxy.
     actor = Class.new(Person)

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -17,7 +17,6 @@ require 'mocha/setup'
 
 class BaseTest < ActiveSupport::TestCase
   def setup
-    ActiveResource::Base.include_root_in_json = true
     setup_response # find me in abstract_unit
     @original_person_site = Person.site
   end


### PR DESCRIPTION
Fixes the following intermittent test failures, the result of subtle ordering dependencies:

```
  Failure:
BaseTest#test_proxy_reader_uses_superclass_site_until_written:
Failed assertion, no message given.

  Failure:
CustomMethodsTest#test_custom_new_element_method:
--- expected
+++ actual
@@ -1 +1 @@
-"{\"person\":{\"name\":\"Ryan\"}}"
+"{\"name\":\"Ryan\"}"

  Failure:
SchemaTest#test_should_not_care_about_ordering_of_schema_definitions:
sanity check - should have a blank class schema
```