### PR TITLE
Avoid using alias_method_chain, now deprecated in Active Support

### DIFF
--- a/lib/active_resource/observing.rb
+++ b/lib/active_resource/observing.rb
@@ -14,7 +14,8 @@ module ActiveResource
         #   end
         #   result
         # end
-        # alias_method_chain(create, :notifications)
+        # alias_method :create_without_notifications, :create
+        # alias_method :create, :create_with_notifications
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
           def #{method}_with_notifications(*args, &block)
             notify_observers(:before_#{method})
@@ -24,7 +25,9 @@ module ActiveResource
             result
           end
         EOS
-        alias_method_chain(method, :notifications)
+
+        alias_method :"#{method}_without_notifications", :"#{method}"
+        alias_method :"#{method}", :"#{method}_with_notifications"
       end
     end
   end

--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -100,7 +100,8 @@ module ActiveResource
     include ActiveModel::Validations
 
     included do
-      alias_method_chain :save, :validation
+      alias_method :save_without_validation, :save
+      alias_method :save, :save_with_validation
     end
 
     # Validate a resource and save (POST) it to the remote web service.


### PR DESCRIPTION
The less than venerable `#alias_method_chain` has been deprecated in the latest version of Active Support. Replace with the longhand version using `alias_method` for forward compatibility. Not using `Module#prepend` in order to maintain compatibility with older versions of Ruby.