### PR TITLE
Fix the duplicated key warning by removing the sample itself

### DIFF
--- a/test/cases/base/custom_methods_test.rb
+++ b/test/cases/base/custom_methods_test.rb
@@ -11,7 +11,6 @@ class CustomMethodsTest < ActiveSupport::TestCase
     @ryan  = { :person => { :name => 'Ryan' } }.to_json
     @addy  = { :address => { :id => 1, :street => '12345 Street' } }.to_json
     @addy_deep  = { :address => { :id => 1, :street => '12345 Street', :zip => "27519" } }.to_json
-    @active = [{ id: 1, name: "Matz", id: 5, name: "Bob" }].to_json
 
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get    "/people/1.json",        {}, @matz
@@ -104,7 +103,7 @@ class CustomMethodsTest < ActiveSupport::TestCase
     path_with_format = "/people/active.json"
 
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get      path_with_format, {}, @active
+      mock.get      path_with_format, {}, @matz
       mock.post     path_with_format, {}, nil
       mock.patch    path_with_format, {}, nil
       mock.delete   path_with_format, {}, nil
@@ -124,7 +123,7 @@ class CustomMethodsTest < ActiveSupport::TestCase
     path_without_format = "/people/active"
 
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get      path_without_format, {}, @active
+      mock.get      path_without_format, {}, @matz
       mock.post     path_without_format, {}, nil
       mock.patch    path_without_format, {}, nil
       mock.delete   path_without_format, {}, nil


### PR DESCRIPTION
Removes `@active` in favor of using `@matz` since they tests don't actually care about the records, but the `path` and `method` used.