### PR TITLE
Fix and improve the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,32 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.2
   - jruby-19mode
   - rbx-2
 
 gemfile:
+  - gemfiles/Gemfile-rails-4-0-stable
   - gemfiles/Gemfile-rails-master
   - Gemfile
 
 matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: Gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile-rails-master
+    - rvm: jruby-19mode
+      gemfile: Gemfile
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile-rails-master
+    - rvm: 2.0.0
+      gemfile: Gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile-rails-master
   allow_failures:
     - gemfile: gemfiles/Gemfile-rails-master
+  fast_finish: true
 
 notifications:
   email: false

--- a/gemfiles/Gemfile-rails-4-0-stable
+++ b/gemfiles/Gemfile-rails-4-0-stable
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', github: 'rails/rails', branch: '4-0-stable'
+
+gemspec path: '..'

--- a/gemfiles/Gemfile-rails-master
+++ b/gemfiles/Gemfile-rails-master
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in protected_attributes.gemspec
 gem 'rails', github: 'rails/rails', branch: 'master'
 gem 'arel', github: 'rails/arel', branch: 'master'
+gem 'rails-observers', github: 'rails/rails-observers', branch: 'master'
 
-gemspec :path => '..'
+gemspec path: '..'


### PR DESCRIPTION
Add a new Gemfile to test with `rails-4-0-stable`.

Remove comment with wrong project reference from `Gemfile-rails-master`.

Add RVM `2.2.2` to `.travis.yml` and exclude `rails-5` builds from `1.9.3`, `jruby-19mode` and `2.0.0` due to no full support.

Since `Gemfile-rails-master` is allowed to fail, I also added the `:fast_finish` option so the build can finish earlier.

Let's see how the builds go :see_no_evil: 