### PR TITLE
Handle responses with more than one root by setting `.remove_root = true`

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -295,6 +295,7 @@ module ActiveResource
     class_attribute :include_format_in_path
     self.include_format_in_path = true
 
+    class_attribute :remove_root
 
     class << self
       include ThreadsafeAttributes
@@ -1331,11 +1332,11 @@ module ActiveResource
       raise ArgumentError, "expected an attributes Hash, got #{attributes.inspect}" unless attributes.is_a?(Hash)
       @prefix_options, attributes = split_options(attributes)
 
-      if attributes.keys.size == 1
-        remove_root = self.class.element_name == attributes.keys.first.to_s
+      if attributes.keys.size == 1 || self.class.remove_root
+        remove_root = attributes.keys.include?(self.class.element_name.to_sym)
       end
 
-      attributes = Formats.remove_root(attributes) if remove_root
+      attributes = Formats.remove_root(attributes, self.class) if remove_root
 
       attributes.each do |key, value|
         @attributes[key.to_s] =

--- a/lib/active_resource/formats.rb
+++ b/lib/active_resource/formats.rb
@@ -11,9 +11,15 @@ module ActiveResource
       ActiveResource::Formats.const_get(ActiveSupport::Inflector.camelize(mime_type_reference.to_s) + "Format")
     end
 
-    def self.remove_root(data)
-      if data.is_a?(Hash) && data.keys.size == 1
-        data.values.first
+    def self.remove_root(data, klass=nil)
+      if data.is_a?(Hash)
+        if data.keys.size == 1
+          data.values.first
+        elsif klass && klass.remove_root
+          data[klass.element_name.to_sym]
+        else
+          data
+        end
       else
         data
       end

--- a/test/cases/base/load_test.rb
+++ b/test/cases/base/load_test.rb
@@ -12,6 +12,11 @@ module Highrise
     self.site = "http://37s.sunrise.i:3000"
   end
 
+  class User < ActiveResource::Base
+    self.site = "http://37s.sunrise.i:3000"
+    self.remove_root = true
+  end
+
   module Deeply
     module Nested
       class Note < ActiveResource::Base
@@ -201,5 +206,17 @@ class BaseLoadTest < ActiveSupport::TestCase
   def test_nested_collections_in_different_levels_of_namespaces
     n = Highrise::Deeply::Nested::TestDifferentLevels::Note.new(:comments => [{ :name => "1" }])
     assert_kind_of Highrise::Deeply::Nested::Comment, n.comments.first
+  end
+
+  def test_multiple_root_keys_and_removing_root_by_default
+    user = Highrise::User.new
+    user.load(:user => {:name => "dbar"}, :other => {:data => 123})
+    assert_equal user.name, "dbar"
+  end
+
+  def test_multiple_root_keys_first_key_not_resource_root_and_removing_root_by_default
+    user = Highrise::User.new
+    user.load(:other => {:data => 123}, :user => {:name => "dbar"})
+    assert_equal user.name, "dbar"
   end
 end


### PR DESCRIPTION
- `Formats.remove_root` has to accept the class to know the element name
- Do not assume the first key is the root

[#175]
