### PR TITLE
Fixes to the has_many finder builder

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -147,7 +147,7 @@ module ActiveResource::Associations
       elsif !new_record?
         instance_variable_set(ivar_name, association_model.find(:all, :params => {:"#{self.class.element_name}_id" => self.id}))
       else
-        instance_variable_set(ivar_name, self.class.collection_parser.new)
+        instance_variable_set(ivar_name, association_model.collection_parser.new)
       end
     end
   end

--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -145,7 +145,7 @@ module ActiveResource::Associations
       elsif attributes.include?(method_name)
         attributes[method_name]
       elsif !new_record?
-        instance_variable_set(ivar_name, association_model.find(:all, :params => {:"#{self.class.element_name}_id" => self.id}))
+        instance_variable_set(ivar_name, association_model.find(:all, :from => "#{self.class.prefix}#{self.class.collection_name}/#{self.id}/#{association_model.collection_name}#{self.class.format_extension}"))
       else
         instance_variable_set(ivar_name, association_model.collection_parser.new)
       end

--- a/test/cases/association_test.rb
+++ b/test/cases/association_test.rb
@@ -60,6 +60,16 @@ class AssociationTest < ActiveSupport::TestCase
     assert_equal person.posts, [post]
   end
 
+  def test_defines_has_many_finder_method_with_persisted_record
+    Person.defines_has_many_finder_method(:posts, Post)
+    person = Person.new
+    person.id = 123
+    person.stubs(:new_record?).returns(false)
+    post = Post.new
+    Post.expects(:find).with(:all, :from => '/people/123/posts.json').once().returns([post])
+    assert_equal person.posts, [post]
+  end
+
   def test_defines_has_many_finder_method
     Person.defines_has_many_finder_method(:posts, Post)
     person = Person.new

--- a/test/cases/association_test.rb
+++ b/test/cases/association_test.rb
@@ -1,15 +1,15 @@
 require 'abstract_unit'
 
 require 'fixtures/person'
+require 'fixtures/post'
+require 'fixtures/post_collection'
 require 'fixtures/beast'
 require 'fixtures/customer'
-
 
 class AssociationTest < ActiveSupport::TestCase
   def setup
     @klass = ActiveResource::Associations::Builder::Association
   end
-
 
   def test_validations_for_instance
     object = @klass.new(Person, :customers, {})
@@ -42,6 +42,29 @@ class AssociationTest < ActiveSupport::TestCase
     Post.send(:has_many, :topics)
     Topic.stubs(:find).returns([:unexpected_response])
     assert_equal [], Post.new.topics.to_a
+  end
+
+  def test_defines_has_many_finder_method_with_instance_variable_cache
+    Person.defines_has_many_finder_method(:posts, Post)
+    person = Person.new
+    post = Post.new
+    person.instance_variable_set(:@posts, [post])
+    assert_equal person.posts, [post]
+  end
+
+  def test_defines_has_many_finder_method_with_existing_attribute
+    Person.defines_has_many_finder_method(:posts, Post)
+    person = Person.new
+    post = Post.new
+    person.attributes['posts'] = [post]
+    assert_equal person.posts, [post]
+  end
+
+  def test_defines_has_many_finder_method
+    Person.defines_has_many_finder_method(:posts, Post)
+    person = Person.new
+    Post.collection_parser = PostCollection
+    assert_kind_of PostCollection, person.posts
   end
 
   def test_has_one

--- a/test/fixtures/post_collection.rb
+++ b/test/fixtures/post_collection.rb
@@ -1,0 +1,2 @@
+class PostCollection < ActiveResource::Collection
+end


### PR DESCRIPTION
This is my first PR to any Rails project, so let me know if I'm overstepping my bounds or if I missed the memo about how all this works.

I am attempting to resolve two bugs in the `has_many` association (one documented, one not).

The undocumented bug is that if you call a `has_many` association on a new record, it returns the collection parser **for that record's class**. It should probably return the collection parser for the associated class, no?

The other bug is documented [here](/rails/activeresource/issues/54) and [here](/rails/activeresource/issues/16). In short, the documentation says:

```
# If the response body does not contain an attribute matching the association name
# a request sent to the index action under the current resource.
# For the example above, if the comments are not present the requested path would be:
# GET /posts/123/comments.xml
```

But that does not seem to be the case. In actuality, the behavior generates a URL like:

```
GET comments.xml?post_id=123
```

I believe this PR fixes both those bugs. But I will do further testing to be sure.
