### PR TITLE
Upgrade ActiveResource for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ before_install:
   - gem --version
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1 # tests on latest 2.1.x
   - 2.2 # tests on latest 2.2.x
   - jruby-19mode
   - rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'rails', github: 'rails/rails'
+gem 'activesupport', github: 'rails/rails'
+gem 'activemodel', github: 'rails/rails'
 gem 'arel', github: 'rails/arel'
 gem 'rails-observers', github: 'rails/rails-observers'
+gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml'
 
 gemspec
 

--- a/activeresource.gemspec
+++ b/activeresource.gemspec
@@ -19,11 +19,12 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w( README.rdoc )
   s.rdoc_options.concat ['--main',  'README.rdoc']
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency('activesupport', '>= 4.0')
-  s.add_dependency('activemodel',   '>= 4.0')
+  s.add_dependency('activesupport', '~> 5.x')
+  s.add_dependency('activemodel',   '~> 5.x')
   s.add_dependency('rails-observers', '~> 0.1.2')
+  s.add_dependency('activemodel-serializers-xml', '~> 0.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '>= 0.13.0')

--- a/gemfiles/Gemfile-rails-master
+++ b/gemfiles/Gemfile-rails-master
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in protected_attributes.gemspec
-gem 'rails', github: 'rails/rails', branch: 'master'
+gem 'activesupport', github: 'rails/rails', branch: 'master'
+gem 'activemodel', github: 'rails/rails', branch: 'master'
 gem 'arel', github: 'rails/arel', branch: 'master'
+gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml'
 
 gemspec :path => '..'

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -20,6 +20,8 @@ require 'active_resource/associations'
 require 'active_resource/reflection'
 require 'active_resource/threadsafe_attributes'
 
+require 'active_model/serializers/xml'
+
 module ActiveResource
   # ActiveResource::Base is the main class for mapping RESTful resources as models in a Rails application.
   #

--- a/lib/active_resource/version.rb
+++ b/lib/active_resource/version.rb
@@ -1,6 +1,6 @@
 module ActiveResource
   module VERSION #:nodoc:
-    MAJOR = 4
+    MAJOR = 5
     MINOR = 0
     TINY  = 0
     PRE   = nil


### PR DESCRIPTION
Rails 5 requires Ruby 2.2.2 or higher. Tests for 2.0 and below have been
failing for some time on this gem anyway.

Additionally this adds `activemodel-serializers-xml` since that was
extracted to a gem and removed in Rails 5.

I swapped the Rails in the gemfile to use the specified gems so we don't
have to require sprockets and sprockets-rails in it since this gem
doesn't even use those gems.