### PR TITLE
Adding Inch-CI badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@ Contributing to Active Resource
 =====================
 
 [![Build Status](https://travis-ci.org/rails/activeresource.svg?branch=master)](https://travis-ci.org/rails/activeresource)
+[![Documentation Status](http://inch-ci.org/github/rails/activeresource.svg?branch=master)](http://inch-ci.org/github/rails/activeresource)
 
 Active Resource is work of [many contributors](https://github.com/rails/activeresource/graphs/contributors). You're encouraged to submit [pull requests](https://github.com/rails/activeresource/pulls), [propose features and discuss issues](https://github.com/rails/activeresource/issues).
 


### PR DESCRIPTION
With this PR i would like to add [Inch-CI](http://inch-ci.org/) to Active Resource. 

You can find the detailed page for Active Resource [here](http://inch-ci.org/github/rails/activeresource/branch/master)

In case we decide to use this, we would just need to add a webhook to the project, like described here:
http://inch-ci.org/help/webhook

What do you guys think of continuous checking for good inline documentation, as well?

/cc @rafaelfranca