### PR TITLE
Exclude params from model's update.

### DIFF
--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -141,6 +141,7 @@ def setup_response
     # products
     mock.get '/products/1.json', {}, @product
     mock.get '/products/1/inventory.json', {}, @inventory
+
   end
 
   Person.user = nil

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -11,6 +11,7 @@ require "fixtures/post"
 require "fixtures/comment"
 require "fixtures/product"
 require "fixtures/inventory"
+require "fixtures/device"
 require 'active_support/json'
 require 'active_support/core_ext/hash/conversions'
 require 'mocha/setup'
@@ -1429,6 +1430,29 @@ class BaseTest < ActiveSupport::TestCase
     plan.price = 10.00
     plan.save!
     assert_equal 10.00, plan.price
+  end
+
+  def test_update_ignoring_params
+    device_body = { :device => { :id => 1, :code => "XYZ1234", :name => 'My Phone' } }.to_json
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get "/devices/1.json", {}, device_body
+      mock.put "/devices/1.json", {}, nil, 204
+    end
+
+    device = Device.find(1)
+    assert !device.new?
+    assert_equal 'XYZ1234', device.code
+    assert_equal 1, device.id
+
+    # update name
+    device.name = 'My Phone 1'
+    device.save!
+    assert_equal 'My Phone 1', device.name
+
+    device_request = { :device => { :name => 'My Phone 1' } }.to_json
+    expected_request = ActiveResource::Request.new(:put, "/devices/1.json", device_request, { "Content-Type" => "application/json" })
+    assert_includes ActiveResource::HttpMock.requests, expected_request
   end
 
   def test_namespacing

--- a/test/fixtures/device.rb
+++ b/test/fixtures/device.rb
@@ -1,0 +1,7 @@
+class Device < ActiveResource::Base
+  self.site = "http://37s.sunrise.i:3000"
+  self.element_name = 'device'
+
+  self.except_primary_key = true
+  update_except :code
+end


### PR DESCRIPTION
If your API throws an exception when unexpected params are received, you
must have a way to stop sending them (even if you receive them in a get
request).

This change introduces two new `ActiveResource::Base`'s class
methods: `update_except` and `update_except_primary_key`. This way when
updating a model, the params specified in `update_except` are not sent
to the API, and if the `update_except_primary_key` is set, the `id` is
not sent in the request's body.

Even though this implementation works, I believe that the naming is not quite right, so I'd love some suggestions about it.
