### PR TITLE
Introduce support for distinct open and read timeouts

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -286,6 +286,16 @@ module ActiveResource
   # Internally, Active Resource relies on Ruby's Net::HTTP library to make HTTP requests. Setting +timeout+
   # sets the <tt>read_timeout</tt> of the internal Net::HTTP instance to the same value. The default
   # <tt>read_timeout</tt> is 60 seconds on most Ruby implementations.
+  #
+  # Active Resource also supports distinct +open_timeout+ (time to connect) and +read_timeout+ (how long to
+  # wait for an upstream response). This is inline with supported +Net::HTTP+ timeout configuration and allows
+  # for finer control of client timeouts depending on context.
+  #
+  #   class Person < ActiveResource::Base
+  #     self.site = "https://api.people.com"
+  #     self.open_timeout = 2
+  #     self.read_timeout = 10
+  #   end
   class Base
     ##
     # :singleton-method:
@@ -555,12 +565,42 @@ module ActiveResource
         @timeout = timeout
       end
 
+      # Sets the number of seconds after which connection attempts to the REST API should time out.
+      def open_timeout=(timeout)
+        self._connection = nil
+        @open_timeout = timeout
+      end
+
+      # Sets the number of seconds after which reads to the REST API should time out.
+      def read_timeout=(timeout)
+        self._connection = nil
+        @read_timeout = timeout
+      end
+
       # Gets the number of seconds after which requests to the REST API should time out.
       def timeout
         if defined?(@timeout)
           @timeout
         elsif superclass != Object && superclass.timeout
           superclass.timeout
+        end
+      end
+
+      # Gets the number of seconds after which connection attempts to the REST API should time out.
+      def open_timeout
+        if defined?(@open_timeout)
+          @open_timeout
+        elsif superclass != Object && superclass.open_timeout
+          superclass.open_timeout
+        end
+      end
+
+      # Gets the number of seconds after which reads to the REST API should time out.
+      def read_timeout
+        if defined?(@read_timeout)
+          @read_timeout
+        elsif superclass != Object && superclass.read_timeout
+          superclass.read_timeout
         end
       end
 
@@ -600,6 +640,8 @@ module ActiveResource
           _connection.password = password if password
           _connection.auth_type = auth_type if auth_type
           _connection.timeout = timeout if timeout
+          _connection.open_timeout = open_timeout if open_timeout
+          _connection.read_timeout = read_timeout if read_timeout
           _connection.ssl_options = ssl_options if ssl_options
           _connection
         else

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -20,7 +20,7 @@ module ActiveResource
       :head => 'Accept'
     }
 
-    attr_reader :site, :user, :password, :auth_type, :timeout, :proxy, :ssl_options
+    attr_reader :site, :user, :password, :auth_type, :timeout, :open_timeout, :read_timeout, :proxy, :ssl_options
     attr_accessor :format
 
     class << self
@@ -69,6 +69,16 @@ module ActiveResource
     # Sets the number of seconds after which HTTP requests to the remote service should time out.
     def timeout=(timeout)
       @timeout = timeout
+    end
+
+    # Sets the number of seconds after which HTTP connects to the remote service should time out.
+    def open_timeout=(timeout)
+      @open_timeout = timeout
+    end
+
+    # Sets the number of seconds after which HTTP read requests to the remote service should time out.
+    def read_timeout=(timeout)
+      @read_timeout = timeout
     end
 
     # Hash of options applied to Net::HTTP instance when +site+ protocol is 'https'.
@@ -180,6 +190,8 @@ module ActiveResource
             https.open_timeout = @timeout
             https.read_timeout = @timeout
           end
+          https.open_timeout = @open_timeout if defined?(@open_timeout)
+          https.read_timeout = @read_timeout if defined?(@read_timeout)
         end
       end
 

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -100,6 +100,18 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal(5, Forum.connection.timeout)
   end
 
+  def test_should_accept_setting_open_timeout
+    Forum.open_timeout = 5
+    assert_equal(5, Forum.open_timeout)
+    assert_equal(5, Forum.connection.open_timeout)
+  end
+
+  def test_should_accept_setting_read_timeout
+    Forum.read_timeout = 5
+    assert_equal(5, Forum.read_timeout)
+    assert_equal(5, Forum.connection.read_timeout)
+  end
+
   def test_should_accept_setting_ssl_options
     expected = {:verify => 1}
     Forum.ssl_options= expected
@@ -135,6 +147,26 @@ class BaseTest < ActiveSupport::TestCase
     actor.timeout = nil
     assert_nil actor.timeout
     assert_nil actor.connection.timeout
+  end
+
+  def test_open_timeout_variable_can_be_reset
+    actor = Class.new(ActiveResource::Base)
+    actor.site = 'http://cinema'
+    assert_nil actor.open_timeout
+    actor.open_timeout = 5
+    actor.open_timeout = nil
+    assert_nil actor.open_timeout
+    assert_nil actor.connection.open_timeout
+  end
+
+  def test_read_timeout_variable_can_be_reset
+    actor = Class.new(ActiveResource::Base)
+    actor.site = 'http://cinema'
+    assert_nil actor.read_timeout
+    actor.read_timeout = 5
+    actor.read_timeout = nil
+    assert_nil actor.read_timeout
+    assert_nil actor.connection.read_timeout
   end
 
   def test_ssl_options_hash_can_be_reset
@@ -358,6 +390,54 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal fruit.timeout, apple.timeout, 'subclass did not adopt changes from parent class'
   end
 
+  def test_open_and_read_timeout_readers_uses_superclass_timeout_until_written
+    # Superclass is Object so returns nil.
+    assert_nil ActiveResource::Base.open_timeout
+    assert_nil Class.new(ActiveResource::Base).open_timeout
+    assert_nil ActiveResource::Base.read_timeout
+    assert_nil Class.new(ActiveResource::Base).read_timeout
+    Person.open_timeout = 5
+    Person.read_timeout = 5
+
+    # Subclass uses superclass open and read timeouts.
+    actor = Class.new(Person)
+    assert_equal Person.open_timeout, actor.open_timeout
+    assert_equal Person.read_timeout, actor.read_timeout
+
+    # Changing subclass open and read timeouts doesn't change superclass timeouts.
+    actor.open_timeout = 10
+    actor.read_timeout = 10
+    assert_not_equal Person.open_timeout, actor.open_timeout
+    assert_not_equal Person.read_timeout, actor.read_timeout
+
+    # Changing superclass open and read timeouts doesn't overwrite subclass timeouts.
+    Person.open_timeout = 15
+    Person.read_timeout = 15
+    assert_not_equal Person.open_timeout, actor.open_timeout
+    assert_not_equal Person.read_timeout, actor.read_timeout
+
+    # Changing superclass open and read timeouts after subclassing changes subclass timeouts.
+    jester = Class.new(actor)
+    actor.open_timeout = 20
+    actor.read_timeout = 20
+    assert_equal actor.open_timeout, jester.open_timeout
+    assert_equal actor.read_timeout, jester.read_timeout
+
+    # Subclasses are always equal to superclass open and read timeouts when not overridden.
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+
+    fruit.open_timeout = 25
+    fruit.read_timeout = 25
+    assert_equal fruit.open_timeout, apple.open_timeout, 'subclass did not adopt changes from parent class'
+    assert_equal fruit.read_timeout, apple.read_timeout, 'subclass did not adopt changes from parent class'
+
+    fruit.open_timeout = 30
+    fruit.read_timeout = 30
+    assert_equal fruit.open_timeout, apple.open_timeout, 'subclass did not adopt changes from parent class'
+    assert_equal fruit.read_timeout, apple.read_timeout, 'subclass did not adopt changes from parent class'
+  end
+
   def test_primary_key_uses_superclass_primary_key_until_written
     # Superclass is Object so defaults to 'id'
     assert_equal 'id', ActiveResource::Base.primary_key
@@ -488,6 +568,26 @@ class BaseTest < ActiveSupport::TestCase
 
     fruit.timeout = 10
     assert_equal fruit.connection.timeout, apple.connection.timeout
+    second_connection = apple.connection.object_id
+    assert_not_equal(first_connection, second_connection, 'Connection should be re-created')
+  end
+
+  def test_updating_baseclass_read_and_open_timeouts_wipes_descendent_cached_connection_objects
+    # Subclasses are always equal to superclass timeout when not overridden
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = 'http://market'
+
+    fruit.open_timeout = 1
+    fruit.read_timeout = 5
+    assert_equal fruit.connection.open_timeout, apple.connection.open_timeout
+    assert_equal fruit.connection.read_timeout, apple.connection.read_timeout
+    first_connection = apple.connection.object_id
+
+    fruit.open_timeout = 2
+    fruit.read_timeout = 10
+    assert_equal fruit.connection.open_timeout, apple.connection.open_timeout
+    assert_equal fruit.connection.read_timeout, apple.connection.read_timeout
     second_connection = apple.connection.object_id
     assert_not_equal(first_connection, second_connection, 'Connection should be re-created')
   end


### PR DESCRIPTION
The current implementation of a single global `ActiveResource::Base.timeout` accessor applies the same `open` and `read` timeout values to the underlying `Net::HTTP` client.

This isn't desired in all cases and depending on context (well most of the time actually), a much lower `open / connect` timeout in relation to the `read` one is preferred, especially under flaky network conditions.