### PR TITLE
add parser callback with [before, around, after] hooks

### DIFF
--- a/lib/active_resource/callbacks.rb
+++ b/lib/active_resource/callbacks.rb
@@ -7,7 +7,8 @@ module ActiveResource
     CALLBACKS = [
       :before_validation, :after_validation, :before_save, :around_save, :after_save,
       :before_create, :around_create, :after_create, :before_update, :around_update,
-      :after_update, :before_destroy, :around_destroy, :after_destroy
+      :after_update, :before_destroy, :around_destroy, :after_destroy, :before_parser,
+      :around_parser, :after_parser
     ]
 
     included do

--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -50,7 +50,9 @@ module ActiveResource
 
     # Grabs errors from a json response.
     def from_json(json, save_cache = false)
-      decoded = ActiveSupport::JSON.decode(json) || {} rescue {}
+      decoded = run_callbacks :parser do
+        ActiveSupport::JSON.decode(json) || {} rescue {}
+      end
       if decoded.kind_of?(Hash) && (decoded.has_key?('errors') || decoded.empty?)
         errors = decoded['errors'] || {}
         if errors.kind_of?(Array)
@@ -70,7 +72,9 @@ module ActiveResource
 
     # Grabs errors from an XML response.
     def from_xml(xml, save_cache = false)
-      array = Array.wrap(Hash.from_xml(xml)['errors']['error']) rescue []
+      array = run_callbacks :parser do
+        Array.wrap(Hash.from_xml(xml)['errors']['error']) rescue []
+      end
       from_array array, save_cache
     end
   end


### PR DESCRIPTION
Create callbacks for before_parser, around_parser, after_parser. The proposal is to transform data before error or load hash handlers. 