### PR TITLE
avoid a second call to schema method

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -381,7 +381,7 @@ module ActiveResource
             @known_attributes << k
           end
 
-          schema
+          @schema
         else
           @schema ||= nil
         end
@@ -1611,4 +1611,3 @@ module ActiveResource
 
   ActiveSupport.run_load_hooks(:active_resource, Base)
 end
-


### PR DESCRIPTION
No need to recall method schema without a block to return the instance variable.