### PR TITLE
Setting a threadsafe attribute in a thread also sets an equal value for the main thread, if no value has been set

### DIFF
--- a/lib/active_resource/threadsafe_attributes.rb
+++ b/lib/active_resource/threadsafe_attributes.rb
@@ -36,6 +36,9 @@ module ThreadsafeAttributes
 
   def set_threadsafe_attribute(name, value)
     set_threadsafe_attribute_by_thread(name, value, Thread.current)
+    unless threadsafe_attribute_defined_by_thread?(name, Thread.main)
+      set_threadsafe_attribute_by_thread(name, value, Thread.main)
+    end
   end
 
   def threadsafe_attribute_defined?(name)

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -43,4 +43,15 @@ class ThreadsafeAttributesTest < ActiveSupport::TestCase
     end.join
     assert_equal false, @tester.safeattr
   end
+
+  test "#changing a threadsafe attribute in a thread sets an equal value for the main thread, if no value has been set" do
+    refute @tester.safeattr_defined?
+    assert_nil @tester.safeattr
+    Thread.new do
+      @tester.safeattr = "value from child"
+      assert_equal "value from child", @tester.safeattr
+    end.join
+    assert @tester.safeattr_defined?
+    assert_equal "value from child", @tester.safeattr
+  end
 end


### PR DESCRIPTION
A step towards a solution for https://github.com/rails/activeresource/issues/178 (introduced in https://github.com/rails/activeresource/pull/167) , which affects all threaded units of work under these circumstances:

* App init / boot sequence which DOES NOT set attributes such as `site` etc. in the main thread.

As @peterjm mentions in https://github.com/rails/activeresource/issues/178#issuecomment-160755798 , the expected behaviour is:

* Child threads should inherit values set within context of the main thread
* Thus ideally the main thread should define the appropriate values during boot PRIOR to threaded dispatch
* Threadsafe attributes currently inherit from the main thread for child threads but ONLY defines within the context of the current thread.

This PR changes the setter behaviour:

* ALSO propagate an assigned value from the child thread back to the main thread IF IT'S NOT DEFINED THERE YET

It's not a perfect solution, but backwards compatible in threaded contexts. There's also the possibility of warning or even a specific error for the case where the pattern of configuration in the main thread is violated.

@rafaelfranca @peterjm