### PR TITLE
Bump version of activemodel-serializers-xml gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'activesupport', github: 'rails/rails'
 gem 'activemodel', github: 'rails/rails'
 gem 'arel', github: 'rails/arel'
 gem 'rails-observers', github: 'rails/rails-observers'
-gem 'activemodel-serializers-xml', github: 'rails/activemodel-serializers-xml'
 
 gemspec
 

--- a/activeresource.gemspec
+++ b/activeresource.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '~> 5.x')
   s.add_dependency('activemodel',   '~> 5.x')
   s.add_dependency('rails-observers', '~> 0.1.2')
-  s.add_dependency('activemodel-serializers-xml', '~> 0.1')
+  s.add_dependency('activemodel-serializers-xml', '~> 1.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '>= 0.13.0')


### PR DESCRIPTION
The 0.1 version of `activemodel-serializers-xml` no longer exists: https://rubygems.org/gems/activemodel-serializers-xml

This bumps the version to 1.0, so that bundler doesn't fail when attempting to use this repo as a gem.

Note that the `Gemfile` in this project [overrides](https://github.com/rails/activeresource/blob/ba719702d5c8b872d0eedb428f0512a784626660/Gemfile#L7) the version specified in the gemspec, so this change isn't actually tested by the tests. I manually commented out the override and ran the tests locally to ensure they still passed.

@rafaelfranca 