### PR TITLE
Fix uninitialized constant error loading resources with inverse associations

### DIFF
--- a/lib/active_resource/associations/builder/belongs_to.rb
+++ b/lib/active_resource/associations/builder/belongs_to.rb
@@ -7,7 +7,7 @@ module ActiveResource::Associations::Builder
     def build
       validate_options
       reflection = model.create_reflection(self.class.macro, name, options)
-      model.defines_belongs_to_finder_method(reflection.name, reflection.klass, reflection.foreign_key)
+      model.defines_belongs_to_finder_method(reflection)
       return reflection
     end
   end

--- a/lib/active_resource/associations/builder/has_many.rb
+++ b/lib/active_resource/associations/builder/has_many.rb
@@ -5,7 +5,7 @@ module ActiveResource::Associations::Builder
     def build
       validate_options
       model.create_reflection(self.class.macro, name, options).tap do |reflection|
-        model.defines_has_many_finder_method(reflection.name, reflection.klass)
+        model.defines_has_many_finder_method(reflection)
       end
     end
   end

--- a/lib/active_resource/associations/builder/has_one.rb
+++ b/lib/active_resource/associations/builder/has_one.rb
@@ -5,7 +5,7 @@ module ActiveResource::Associations::Builder
     def build
       validate_options
       model.create_reflection(self.class.macro, name, options).tap do |reflection|
-        model.defines_has_one_finder_method(reflection.name, reflection.klass)
+        model.defines_has_one_finder_method(reflection)
       end
     end
   end

--- a/test/cases/associations/builder/belongs_to_test.rb
+++ b/test/cases/associations/builder/belongs_to_test.rb
@@ -19,8 +19,14 @@ class ActiveResource::Associations::Builder::BelongsToTest < ActiveSupport::Test
 
   def test_instance_build
     object = @klass.new(Person, :customer, {})
-    Person.expects(:defines_belongs_to_finder_method).with(:customer, Customer, 'customer_id')
-    assert_kind_of ActiveResource::Reflection::AssociationReflection, object.build
+    Person.expects(:defines_belongs_to_finder_method).with(kind_of(ActiveResource::Reflection::AssociationReflection))
+
+    reflection = object.build
+
+    assert_kind_of ActiveResource::Reflection::AssociationReflection, reflection
+    assert_equal :customer, reflection.name
+    assert_equal Customer, reflection.klass
+    assert_equal 'customer_id', reflection.foreign_key
   end
 
 

--- a/test/cases/associations/builder/has_many_test.rb
+++ b/test/cases/associations/builder/has_many_test.rb
@@ -15,8 +15,13 @@ class ActiveResource::Associations::Builder::HasManyTest < ActiveSupport::TestCa
 
   def test_instance_build
     object = @klass.new(Person, :street_address, {})
-    Person.expects(:defines_has_many_finder_method).with(:street_address, StreetAddress)
-    assert_kind_of ActiveResource::Reflection::AssociationReflection, object.build
+    Person.expects(:defines_has_many_finder_method).with(kind_of(ActiveResource::Reflection::AssociationReflection))
+
+    reflection = object.build
+
+    assert_kind_of ActiveResource::Reflection::AssociationReflection, reflection
+    assert_equal :street_address, reflection.name
+    assert_equal StreetAddress, reflection.klass
   end
 
 end

--- a/test/cases/associations/builder/has_one_test.rb
+++ b/test/cases/associations/builder/has_one_test.rb
@@ -15,9 +15,13 @@ class ActiveResource::Associations::Builder::HasOneTest < ActiveSupport::TestCas
 
   def test_instance_build
     object = @klass.new(Product, :inventory, {})
+    Product.expects(:defines_has_one_finder_method).with(kind_of(ActiveResource::Reflection::AssociationReflection))
 
-    Product.expects(:defines_has_one_finder_method).with(:inventory, Inventory)
-    assert_kind_of ActiveResource::Reflection::AssociationReflection, object.build
+    reflection = object.build
+
+    assert_kind_of ActiveResource::Reflection::AssociationReflection, reflection
+    assert_equal :inventory, reflection.name
+    assert_equal Inventory, reflection.klass
   end
 
 end


### PR DESCRIPTION
Defining inverse associations on resource classes creates a circular dependency. This change defers the lookup of the reflection class until the first invocation of the association finder method.

Code to reproduce:

```ruby
# app.rb
require 'rubygems'
require 'active_resource'

class Park < ActiveResource::Base
  has_many :trails
end

class Trail < ActiveResource::Base
  belongs_to :park
end
```

Resulting error message:

```
$ ruby app.rb
/Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/inflector/methods.rb:261:in `const_get': uninitialized constant Trail (NameError)
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/inflector/methods.rb:261:in `block in constantize'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/inflector/methods.rb:259:in `each'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/inflector/methods.rb:259:in `inject'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/inflector/methods.rb:259:in `constantize'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activeresource-4.0.0/lib/active_resource/reflection.rb:52:in `klass'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activeresource-4.0.0/lib/active_resource/associations/builder/has_many.rb:8:in `block in build'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activeresource-4.0.0/lib/active_resource/associations/builder/has_many.rb:7:in `tap'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activeresource-4.0.0/lib/active_resource/associations/builder/has_many.rb:7:in `build'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activeresource-4.0.0/lib/active_resource/associations/builder/association.rb:14:in `build'
        from /Users/jbach/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activeresource-4.0.0/lib/active_resource/associations.rb:43:in `has_many'
        from app.rb:5:in `<class:Park>'
        from app.rb:4:in `<main>'

```