### PR TITLE
Better check for Rails application

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -42,5 +42,5 @@ module ActiveResource
   autoload :Collection
 end
 
-require 'active_resource/railtie' if defined? Rails
+require 'active_resource/railtie' if defined?(Rails) && defined?(Rails.application)
 

--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -42,5 +42,4 @@ module ActiveResource
   autoload :Collection
 end
 
-require 'active_resource/railtie' if defined?(Rails) && defined?(Rails.application)
-
+require 'active_resource/railtie' if defined?(Rails.application)


### PR DESCRIPTION
Don't trigger loading of `railtie` when there's only `Rails` constant present. Previous version of the code tried to load it when there only was stuff like `rails-observers` of `rails-html-sanitizer` (which is a part of ActionMailer)