### PR TITLE
Add support for using a custom Connection class

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -307,8 +307,8 @@ module ActiveResource
     class_attribute :include_format_in_path
     self.include_format_in_path = true
 
-    class_attribute :connection_klass
-    self.connection_klass = Connection
+    class_attribute :connection_class
+    self.connection_class = Connection
 
 
     class << self
@@ -637,7 +637,7 @@ module ActiveResource
       # or not (defaults to <tt>false</tt>).
       def connection(refresh = false)
         if _connection_defined? || superclass == Object
-          self._connection = connection_klass.new(site, format) if refresh || _connection.nil?
+          self._connection = connection_class.new(site, format) if refresh || _connection.nil?
           _connection.proxy = proxy if proxy
           _connection.user = user if user
           _connection.password = password if password

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -307,6 +307,9 @@ module ActiveResource
     class_attribute :include_format_in_path
     self.include_format_in_path = true
 
+    class_attribute :connection_klass
+    self.connection_klass = Connection
+
 
     class << self
       include ThreadsafeAttributes
@@ -634,7 +637,7 @@ module ActiveResource
       # or not (defaults to <tt>false</tt>).
       def connection(refresh = false)
         if _connection_defined? || superclass == Object
-          self._connection = Connection.new(site, format) if refresh || _connection.nil?
+          self._connection = connection_klass.new(site, format) if refresh || _connection.nil?
           _connection.proxy = proxy if proxy
           _connection.user = user if user
           _connection.password = password if password

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -628,6 +628,17 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal nil, fruit.headers['key2']
   end
 
+  def test_connection_should_use_connection_klass
+    apple = Class.new(ActiveResource::Base)
+    orange = Class.new(ActiveResource::Base)
+    telephone = Class.new(ActiveResource::Connection)
+    orange.connection_klass = telephone
+    apple.site = orange.site = "https://some-site.com/api"
+
+    assert_equal ActiveResource::Connection, apple.connection.class
+    assert_equal telephone, orange.connection.class
+  end
+
   ########################################################################
   # Tests for setting up remote URLs for a given model (including adding
   # parameters appropriately)

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -628,11 +628,11 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal nil, fruit.headers['key2']
   end
 
-  def test_connection_should_use_connection_klass
+  def test_connection_should_use_connection_class
     apple = Class.new(ActiveResource::Base)
     orange = Class.new(ActiveResource::Base)
     telephone = Class.new(ActiveResource::Connection)
-    orange.connection_klass = telephone
+    orange.connection_class = telephone
     apple.site = orange.site = "https://some-site.com/api"
 
     assert_equal ActiveResource::Connection, apple.connection.class


### PR DESCRIPTION
I'm trying to implement support for the "Retry-After" header in the `shopify_api` gem, which inherits from `ActiveResource::Base`. The ideal place to do so is in a subclass of `ActiveResource::Connection`. However, using the custom connection class in a subclass of `ActiveResource::Base` is problematic because the call to `Connection.new` is hardcoded into `ActiveResource::Base#connection`. Overriding `ActiveResource::Base#connection` is another option, but is less than ideal because that method is fairly complicated.

The method `connection_klass=` could also be added but is not strictly necessary.

Please let me know if you have any issues with the proposed code changes. I'll be happy to add documentation and tests later once I hear your feedback.