### PR TITLE
Support password with specials characters

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -177,7 +177,9 @@ module ActiveResource
 
       def new_http
         if @proxy
-          Net::HTTP.new(@site.host, @site.port, @proxy.host, @proxy.port, @proxy.user, @proxy.password)
+          user = URI.parser.unescape(@proxy.user) if @proxy.user
+          password = URI.parser.unescape(@proxy.password) if @proxy.password
+          Net::HTTP.new(@site.host, @site.port, @proxy.host, @proxy.port, user, password)
         else
           Net::HTTP.new(@site.host, @site.port)
         end

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -127,6 +127,24 @@ class ConnectionTest < ActiveSupport::TestCase
     assert_equal proxy, @conn.proxy
   end
 
+  def test_proxy_accessor_accepts_uri_or_string_argument_with_spectials_characters
+    user = "proxy_;{(,!$%_user"
+    password = "proxy_;:{(,!$%_password"
+
+    encoded_user = URI.encode(user) # "proxy_;%7B(,!$%25_user"
+    encoded_password = URI.encode(password) # "proxy_;:%7B(,!$%25_password"
+
+    proxy = URI.parse("http://#{encoded_user}:#{encoded_password}@proxy.local:4242")
+
+    assert_nothing_raised { @conn.proxy = "http://#{encoded_user}:#{encoded_password}@proxy.local:4242" }
+    assert_equal user, @conn.send(:new_http).proxy_user
+    assert_equal password, @conn.send(:new_http).proxy_pass
+
+    assert_nothing_raised { @conn.proxy = proxy }
+    assert_equal user, @conn.send(:new_http).proxy_user
+    assert_equal password, @conn.send(:new_http).proxy_pass
+  end
+
   def test_timeout_accessor
     @conn.timeout = 5
     assert_equal 5, @conn.timeout


### PR DESCRIPTION
Net::HTTP don't apply URI decode before use password.

Signed-off-by: Florian Wininger fw.centrale@gmail.com
