### PR TITLE
Fix threadsafe attributes when using #fork

### DIFF
--- a/lib/active_resource/threadsafe_attributes.rb
+++ b/lib/active_resource/threadsafe_attributes.rb
@@ -5,17 +5,19 @@ module ThreadsafeAttributes
 
   module ClassMethods
     def threadsafe_attribute(*attrs)
+      main_thread = Thread.main # remember this, because it could change after forking
+
       attrs.each do |attr|
         define_method attr do
-          get_threadsafe_attribute(attr)
+          get_threadsafe_attribute(attr, main_thread)
         end
 
         define_method "#{attr}=" do |value|
-          set_threadsafe_attribute(attr, value)
+          set_threadsafe_attribute(attr, value, main_thread)
         end
 
         define_method "#{attr}_defined?" do
-          threadsafe_attribute_defined?(attr)
+          threadsafe_attribute_defined?(attr, main_thread)
         end
       end
     end
@@ -23,26 +25,26 @@ module ThreadsafeAttributes
 
   private
 
-  def get_threadsafe_attribute(name)
+  def get_threadsafe_attribute(name, main_thread)
     if threadsafe_attribute_defined_by_thread?(name, Thread.current)
       get_threadsafe_attribute_by_thread(name, Thread.current)
-    elsif threadsafe_attribute_defined_by_thread?(name, Thread.main)
-      value = get_threadsafe_attribute_by_thread(name, Thread.main)
+    elsif threadsafe_attribute_defined_by_thread?(name, main_thread)
+      value = get_threadsafe_attribute_by_thread(name, main_thread)
       value = value.dup if value
       set_threadsafe_attribute_by_thread(name, value, Thread.current)
       value
     end
   end
 
-  def set_threadsafe_attribute(name, value)
+  def set_threadsafe_attribute(name, value, main_thread)
     set_threadsafe_attribute_by_thread(name, value, Thread.current)
-    unless threadsafe_attribute_defined_by_thread?(name, Thread.main)
-      set_threadsafe_attribute_by_thread(name, value, Thread.main)
+    unless threadsafe_attribute_defined_by_thread?(name, main_thread)
+      set_threadsafe_attribute_by_thread(name, value, main_thread)
     end
   end
 
-  def threadsafe_attribute_defined?(name)
-    threadsafe_attribute_defined_by_thread?(name, Thread.current) || ((Thread.current != Thread.main) && threadsafe_attribute_defined_by_thread?(name, Thread.main))
+  def threadsafe_attribute_defined?(name, main_thread)
+    threadsafe_attribute_defined_by_thread?(name, Thread.current) || ((Thread.current != main_thread) && threadsafe_attribute_defined_by_thread?(name, main_thread))
   end
 
   def get_threadsafe_attribute_by_thread(name, thread)


### PR DESCRIPTION
ActiveResource's implementation of thread safety can fail after using `fork`.

For example:
```
ActiveResource::Base.site = 'http://localhost'
Thread.new { fork { p ActiveResource::Base.site } }
=> nil
```

The reason is that some attributes are stored as local variables on `Thread.main`, but `Thread.main` will change when forking from within a thread.