### PR TITLE
Implement create! (same as create, but raises on HTTP 422 / validation failures, like save!)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Add `ActiveResource::Base#create!`.
+
 *   Move observers support to rails-observers gem.
 
 *   Remove support to Rails 4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add `ActiveResource::Base#create!`.
+*   Add `ActiveResource::Base.create!`.
 
 *   Move observers support to rails-observers gem.
 

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -856,6 +856,17 @@ module ActiveResource
         self.new(attributes).tap { |resource| resource.save }
       end
 
+      # Creates a new resource (just like <tt>create</tt>) and makes a request to the
+      # remote service that it be saved, but runs validations and raises
+      # <tt>ActiveResource::ResourceInvalid</tt>, making it equivalent to the following
+      # simultaneous calls:
+      #
+      #   ryan = Person.new(:first => 'ryan')
+      #   ryan.save!
+      def create!(attributes = {})
+        self.new(attributes).tap { |resource| resource.save! }
+      end
+
       # Core method for finding resources. Used similarly to Active Record's +find+ method.
       #
       # ==== Arguments

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -969,6 +969,19 @@ class BaseTest < ActiveSupport::TestCase
     assert_nil person.id
   end
 
+  def test_create!
+    rick = Person.create(:name => 'Rick')
+    rick_bang = Person.create!(:name => 'Rick')
+
+    assert_equal rick.id, rick_bang.id
+    assert_equal rick.age, rick_bang.age
+
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.post   "/people.json", {}, nil, 422
+    end
+    assert_raise(ActiveResource::ResourceInvalid) { Person.create!(:name => 'Rick') }
+  end
+
   def test_clone
     matz = Person.find(1)
     matz_c = matz.clone


### PR DESCRIPTION
### Why?

The `save` and `save!` instance methods behave much like their Active Record counterparts. `save!` is great when you don't expect data to be invalid (and want to avoid silent failures), but there isn't an equivalent method for `.create` (as opposed to Active Record, which [provides `create!`](http://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-create-21)).

One can work around that with `new` + `save!`, but a `create!` method makes code more consistent and readable.

### Implementation

Opted to repeat the one-liner `create`, but using `save!` instead (as the later is much more likely to change than the `create` mechanism itself), but would be happy to hear of "DRY-er" approaches.