### PR TITLE
Set headers in main thread from another thread if no value has been set yet.

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -652,11 +652,11 @@ module ActiveResource
       end
 
       def headers
-        self._headers ||= {}
-        if superclass != Object && superclass.headers
-          self._headers = superclass.headers.merge(_headers)
+        headers_state = self._headers || {}
+        if superclass != Object
+          self._headers = superclass.headers.merge(headers_state)
         else
-          _headers
+          headers_state
         end
       end
 

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -628,6 +628,21 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal nil, fruit.headers['key2']
   end
 
+  def test_header_should_be_copied_to_main_thread_if_not_defined
+    fruit = Class.new(ActiveResource::Base)
+
+    Thread.new do
+      fruit.site = 'http://market'
+      assert_equal 'http://market', fruit.site.to_s
+
+      fruit.headers['key'] = 'value'
+      assert_equal 'value', fruit.headers['key']
+    end.join
+
+    assert_equal 'http://market', fruit.site.to_s
+    assert_equal 'value', fruit.headers['key']
+  end
+
   def test_connection_should_use_connection_class
     apple = Class.new(ActiveResource::Base)
     orange = Class.new(ActiveResource::Base)


### PR DESCRIPTION
Fixes #219 

The current behaviour sets an empty Hash for headers in the main thread, but we should get the value from another thread if the main thread doesn't have a value in its headers.

This happens because when we do this:

```ruby
# lib/active_resource/base.rb#L655
self._headers ||= {}
```

We will trigger:

```ruby
# lib/active_resource/threadsafe_attributes.rb#L41
unless threadsafe_attribute_defined_by_thread?(name, main_thread)
  set_threadsafe_attribute_by_thread(name, value, main_thread)
end
```

Which will set an empty Hash for `headers` in the main thread.

Thanks for doing all the research @repinel ! <3