### PR TITLE
Include site.path in belongs_to request

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -167,7 +167,7 @@ module ActiveResource::Associations
       elsif reflection.klass.respond_to?(:singleton_name)
         instance_variable_set(ivar_name, reflection.klass.find(:params => {:"#{self.class.element_name}_id" => self.id}))
       else
-        instance_variable_set(ivar_name, reflection.klass.find(:one, :from => "/#{self.class.collection_name}/#{self.id}/#{method_name}#{self.class.format_extension}"))
+        instance_variable_set(ivar_name, reflection.klass.find(:one, :from => File.join(connection.site.path, "/#{self.class.collection_name}/#{self.id}/#{method_name}#{self.class.format_extension}")))
       end
     end
   end

--- a/test/cases/custom_path_test.rb
+++ b/test/cases/custom_path_test.rb
@@ -1,0 +1,37 @@
+require 'abstract_unit'
+require 'fixtures/person'
+require 'fixtures/custom_path'
+
+class CustomPathTest < ActiveSupport::TestCase
+  def setup
+    setup_response # find me in abstract_unit
+
+    @accepts = { 'Accept' => 'application/json' }
+  end
+
+  def test_parse_non_singleton_resource_with_has_one_makes_get_request_on_child_route
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get '/custom/path/posts/1.json', @accepts, @post
+      mock.get '/custom/path/posts/1/author.json', @accepts, @matz
+    end
+
+    CustomPath::Post.send(:has_one, :author, class_name: 'CustomPath::Person')
+
+    post = CustomPath::Post.find(1)
+
+    assert post.author.name == ActiveSupport::JSON.decode(@matz)['person']['name']
+  end
+
+  def test_parse_resources_with_has_many_makes_get_request_on_nested_route
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get '/custom/path/posts/1.json', @accepts, @post
+      mock.get '/custom/path/posts/1/comments.json', @accepts, @comments
+    end
+
+    CustomPath::Post.send(:has_many, :comments, class_name: 'CustomPath::Comment')
+    post = CustomPath::Post.find(1)
+    post.comments.each do |comment|
+      assert_kind_of CustomPath::Comment, comment
+    end
+  end
+end

--- a/test/fixtures/custom_path.rb
+++ b/test/fixtures/custom_path.rb
@@ -1,0 +1,13 @@
+module CustomPath
+  class Post < ActiveResource::Base
+    self.site = "http://37s.sunrise.i:3000/custom/path"
+  end
+
+  class Person < ActiveResource::Base
+    self.site = "http://37s.sunrise.i:3000/custom/path"
+  end
+
+  class Comment < ActiveResource::Base
+    self.site = "http://37s.sunrise.i:3000/custom/path/posts/:post_id"
+  end
+end


### PR DESCRIPTION
**has_one** right now is using **find** with the **from** form, and it is known that using *from* sets the path to use for the resource to be fetched from.

Due to that behavior, when we configure a site like `Person.site = "http://37s.sunrise.i:3000/custom/path"`, the `custom/path` part is removed from the request.

This fix is only adding `connection.site.path` to the request.