### PR TITLE
Allow non-duplicable values to be used in threadsafe attributes

### DIFF
--- a/lib/active_resource/threadsafe_attributes.rb
+++ b/lib/active_resource/threadsafe_attributes.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/duplicable'
+
 module ThreadsafeAttributes
   def self.included(klass)
     klass.extend(ClassMethods)
@@ -30,7 +32,7 @@ module ThreadsafeAttributes
       get_threadsafe_attribute_by_thread(name, Thread.current)
     elsif threadsafe_attribute_defined_by_thread?(name, main_thread)
       value = get_threadsafe_attribute_by_thread(name, main_thread)
-      value = value.dup if value
+      value = value.dup if value.duplicable?
       set_threadsafe_attribute_by_thread(name, value, Thread.current)
       value
     end

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -55,6 +55,13 @@ class ThreadsafeAttributesTest < ActiveSupport::TestCase
     assert_equal "value from child", @tester.safeattr
   end
 
+  test "#threadsafe attributes can retrieve non-duplicable from main thread" do
+    @tester.safeattr = :symbol_1
+    Thread.new do
+      assert_equal :symbol_1, @tester.safeattr
+    end.join
+  end
+
   unless RUBY_PLATFORM == 'java'
     test "threadsafe attributes can be accessed after forking within a thread" do
       reader, writer = IO.pipe


### PR DESCRIPTION
Same as #242 but now for the 4-stable branch.