### PR TITLE
Add info logs for the sent params on the api requests

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -128,7 +128,7 @@ module ActiveResource
         result = ActiveSupport::Notifications.instrument("request.active_resource") do |payload|
           payload[:method]      = method
           payload[:request_uri] = "#{site.scheme}://#{site.host}:#{site.port}#{path}"
-          payload[:params]      = JSON.parse(arguments[0]) if arguments[0].is_a? String
+          payload[:params]      = get_request_params(arguments[0]) if arguments[0].is_a? String
           payload[:result]      = http.send(method, path, *arguments)
         end
         handle_response(result)
@@ -295,6 +295,15 @@ module ActiveResource
         return :basic if auth_type.nil?
         auth_type = auth_type.to_sym
         auth_type.in?([:basic, :digest]) ? auth_type : :basic
+      end
+
+      def get_request_params(params_string)
+        case format
+          when ActiveResource::Formats::JsonFormat
+            JSON.parse(params_string)
+          when ActiveResource::Formats::XmlFormat
+            Hash.from_xml(params_string)
+        end
       end
   end
 end

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -128,6 +128,7 @@ module ActiveResource
         result = ActiveSupport::Notifications.instrument("request.active_resource") do |payload|
           payload[:method]      = method
           payload[:request_uri] = "#{site.scheme}://#{site.host}:#{site.port}#{path}"
+          payload[:params]      = JSON.parse(arguments[0]) if arguments[0].is_a? String
           payload[:result]      = http.send(method, path, *arguments)
         end
         handle_response(result)

--- a/lib/active_resource/log_subscriber.rb
+++ b/lib/active_resource/log_subscriber.rb
@@ -3,6 +3,7 @@ module ActiveResource
     def request(event)
       result = event.payload[:result]
       info "#{event.payload[:method].to_s.upcase} #{event.payload[:request_uri]}"
+      info "Params sent: #{event.payload[:params].inspect}" if event.payload[:params].present?
       info "--> %d %s %d (%.1fms)" % [result.code, result.message, result.body.to_s.length, event.duration]
     end
 

--- a/test/cases/log_subscriber_test.rb
+++ b/test/cases/log_subscriber_test.rb
@@ -13,6 +13,7 @@ class LogSubscriberTest < ActiveSupport::TestCase
     @matz = { :person => { :id => 1, :name => 'Matz' } }.to_json
     ActiveResource::HttpMock.respond_to do |mock|
       mock.get "/people/1.json", {}, @matz
+      mock.post "/people.json", {}, @matz, 201, 'Location' => '/people/1.json'
     end
 
     ActiveResource::LogSubscriber.attach_to :active_resource
@@ -28,5 +29,14 @@ class LogSubscriberTest < ActiveSupport::TestCase
     assert_equal 2, @logger.logged(:info).size
     assert_equal "GET http://37s.sunrise.i:3000/people/1.json", @logger.logged(:info)[0]
     assert_match(/\-\-\> 200 200 33/, @logger.logged(:info)[1])
+  end
+
+  def test_request_with_params_notification
+    Person.create(name: 'Matz')
+    wait
+    assert_equal 3, @logger.logged(:info).size
+    assert_equal "POST http://37s.sunrise.i:3000/people.json", @logger.logged(:info)[0]
+    assert_equal 'Params sent: {"person"=>{"name"=>"Matz"}}', @logger.logged(:info)[1]
+    assert_match(/\-\-\> 201 201 33/, @logger.logged(:info)[2])
   end
 end


### PR DESCRIPTION
I was recently working on a feature to log all the outbounds requests made by ActiveResource, and I had to write a similar code in a monkey patch to be able to get the actual parameters that ActiveResource is sending to the outbound requests.

Some GET requests pass the parameters via query params, and those are already logged in by the current implementation of `LogSubscriber`, in other hand, POST requests' parameters are not passed via query params so, this code should show the parameters on an extra info log.

I think it can be really helpful to add the parameters info to the payload of the `ActiveSupport::Notification` so the LogSubscriber can use it as required.

The change to the `ActiveResource::LogSubscriber` is not 100% mandatory, it would be nice to see it included.

The `payload[:result]` contains the response body, but I could not found a way to get the actual parameters we send on a POST request from there.