### PR TITLE
Fix threadsafe attributes in fibers

### DIFF
--- a/lib/active_resource/threadsafe_attributes.rb
+++ b/lib/active_resource/threadsafe_attributes.rb
@@ -50,16 +50,15 @@ module ThreadsafeAttributes
   end
 
   def get_threadsafe_attribute_by_thread(name, thread)
-    thread["active.resource.#{name}.#{self.object_id}"]
+    thread.thread_variable_get "active.resource.#{name}.#{self.object_id}"
   end
 
   def set_threadsafe_attribute_by_thread(name, value, thread)
-    thread["active.resource.#{name}.#{self.object_id}.defined"] = true
-    thread["active.resource.#{name}.#{self.object_id}"] = value
+    thread.thread_variable_set "active.resource.#{name}.#{self.object_id}.defined", true
+    thread.thread_variable_set "active.resource.#{name}.#{self.object_id}", value
   end
 
   def threadsafe_attribute_defined_by_thread?(name, thread)
-    thread["active.resource.#{name}.#{self.object_id}.defined"]
+    thread.thread_variable_get "active.resource.#{name}.#{self.object_id}.defined"
   end
-
 end

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -62,6 +62,13 @@ class ThreadsafeAttributesTest < ActiveSupport::TestCase
     end.join
   end
 
+  test "#threadsafe attributes work in fibers" do
+    @tester.safeattr = :symbol_1
+    Fiber.new do
+      assert_equal :symbol_1, @tester.safeattr
+    end.resume
+  end
+
   unless RUBY_PLATFORM == 'java'
     test "threadsafe attributes can be accessed after forking within a thread" do
       reader, writer = IO.pipe


### PR DESCRIPTION
threadsafe attributes are currently broken in Fibers (including when working with Enumerators). I've included a simple test in the commit that fails on master. This causes even very simple use cases to fail when using ActiveResource with fibers:

```ruby
require 'activeresource'

class Github < ActiveResource::Base
  self.site = "https://api.github.com/"
  self.include_format_in_path = false
end

class User < Github
end

p User.find('medlefsen') # works
p Fiber.new { User.find('medlefsen') }.resume # fails with error
```

The bug is caused because the code uses `Thread#[]` and `Thread#[]=` for getting and setting thread local variables. These variables are also Fiber local and so will be empty inside a new Fiber. The code that handles this within a new Thread does not catch it because it's still within the main thread.

The fix, included in this patch, is to use `Thread#thread_local_get` and `Thread#thread_local_set`, which are truly thread local (not fiber local).

