### PR TITLE
Always load 'abstract_unit' on the top of test file.

### DIFF
--- a/test/cases/collection_test.rb
+++ b/test/cases/collection_test.rb
@@ -1,3 +1,5 @@
+require 'abstract_unit'
+
 class CollectionTest < ActiveSupport::TestCase
   def setup
     @collection = ActiveResource::Collection.new

--- a/test/threadsafe_attributes_test.rb
+++ b/test/threadsafe_attributes_test.rb
@@ -1,3 +1,5 @@
+require 'abstract_unit'
+
 class ThreadsafeAttributesTest < ActiveSupport::TestCase
 
   class TestClass


### PR DESCRIPTION
This helps to prevent issues such as:

~~~
+ ruby -Itest -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
/builddir/build/BUILD/activeresource-5.0.0/usr/share/gems/gems/activeresource-5.0.0/test/threadsafe_attributes_test.rb:1:in `<top (required)>': uninitialized constant ActiveSupport (NameError)
from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
from -e:1:in `glob'
from -e:1:in `<main>'
~~~