### PR TITLE
make it compatible with active_model_serializer

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1487,6 +1487,14 @@ module ActiveResource
       super({ :root => self.class.element_name }.merge(options))
     end
 
+    def read_attribute_for_serialization(n)
+      if !attributes[n].nil?
+        attributes[n]
+      elsif respond_to?(n)
+        send(n)
+      end
+    end
+
     protected
       def connection(refresh = false)
         self.class.connection(refresh)
@@ -1538,10 +1546,6 @@ module ActiveResource
       end
 
     private
-
-      def read_attribute_for_serialization(n)
-        attributes[n]
-      end
 
       # Determine whether the response is allowed to have a body per HTTP 1.1 spec section 4.4.1
       def response_code_allows_body?(c)

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1250,6 +1250,24 @@ class BaseTest < ActiveSupport::TestCase
     assert Person.exists?(1)
   end
 
+  def test_read_attribute_for_serialization
+    joe = Person.find(6)
+    joe.singleton_class.class_eval do
+      def non_attribute_field
+        'foo'
+      end
+
+      def id
+        'bar'
+      end
+    end
+
+    assert_equal joe.read_attribute_for_serialization(:id), 6
+    assert_equal joe.read_attribute_for_serialization(:name), 'Joe'
+    assert_equal joe.read_attribute_for_serialization(:likes_hats), true
+    assert_equal joe.read_attribute_for_serialization(:non_attribute_field), 'foo'
+  end
+
   def test_to_xml
     Person.format = :xml
     matz = Person.find(1)


### PR DESCRIPTION
Make read_attribute_for_serialization method public and forward attribute getting to method if the attribute is not a real attribute. In this case, activeresource object can be serialized by active model serializer. 