### PR TITLE
Don't raise a TypeError when trying to parse nil as JSON.

### DIFF
--- a/lib/active_resource/formats/json_format.rb
+++ b/lib/active_resource/formats/json_format.rb
@@ -18,6 +18,7 @@ module ActiveResource
       end
 
       def decode(json)
+        return nil if json.nil?
         Formats.remove_root(ActiveSupport::JSON.decode(json))
       end
     end


### PR DESCRIPTION
Fixes an issue where when some API's return a 204 response for an empty page of
a collection endpoint ActiveResource blows up with a TypeError because it's
unable to parse the 'nil' response body as JSON.

Fixes #159