### PR TITLE
Add a `logger` method to Connection

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -300,7 +300,12 @@ module ActiveResource
     ##
     # :singleton-method:
     # The logger for diagnosing and tracing Active Resource calls.
-    cattr_accessor :logger
+    cattr_reader :logger
+
+    def self.logger=(logger)
+      self._connection = nil
+      @@logger = logger
+    end
 
     class_attribute :_format
     class_attribute :_collection_parser
@@ -636,7 +641,9 @@ module ActiveResource
       # or not (defaults to <tt>false</tt>).
       def connection(refresh = false)
         if _connection_defined? || superclass == Object
-          self._connection = connection_class.new(site, format) if refresh || _connection.nil?
+          self._connection = connection_class.new(
+            site, format: format, logger: logger
+          ) if refresh || _connection.nil?
           _connection.proxy = proxy if proxy
           _connection.user = user if user
           _connection.password = password if password

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -642,7 +642,7 @@ module ActiveResource
       def connection(refresh = false)
         if _connection_defined? || superclass == Object
           self._connection = connection_class.new(
-            site, format: format, logger: logger
+            site, format, logger: logger
           ) if refresh || _connection.nil?
           _connection.proxy = proxy if proxy
           _connection.user = user if user

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -27,7 +27,12 @@ module ActiveResource
       def requests
         @@requests ||= []
       end
+
+      def logger
+        ActiveResource::Base.logger
+      end
     end
+    
 
     # The +site+ parameter is required and will set the +site+
     # attribute to the URI for the remote resource service.
@@ -36,6 +41,11 @@ module ActiveResource
       @proxy = @user = @password = nil
       self.site = site
       self.format = format
+    end
+
+    # defaults to ActiveResource::Base.logger
+    def logger
+      self.class.logger
     end
 
     # Set URI for remote service.

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -31,7 +31,7 @@ module ActiveResource
 
     # The +site+ parameter is required and will set the +site+
     # attribute to the URI for the remote resource service.
-    def initialize(site, format: ActiveResource::Formats::JsonFormat, logger: nil)
+    def initialize(site, format=ActiveResource::Formats::JsonFormat, logger: nil)
       raise ArgumentError, 'Missing site URI' unless site
       @proxy = @user = @password = nil
       self.site = site

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -32,7 +32,6 @@ module ActiveResource
         ActiveResource::Base.logger
       end
     end
-    
 
     # The +site+ parameter is required and will set the +site+
     # attribute to the URI for the remote resource service.

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -21,30 +21,22 @@ module ActiveResource
     }
 
     attr_reader :site, :user, :password, :auth_type, :timeout, :open_timeout, :read_timeout, :proxy, :ssl_options
-    attr_accessor :format
+    attr_accessor :format, :logger
 
     class << self
       def requests
         @@requests ||= []
       end
-
-      def logger
-        ActiveResource::Base.logger
-      end
     end
 
     # The +site+ parameter is required and will set the +site+
     # attribute to the URI for the remote resource service.
-    def initialize(site, format = ActiveResource::Formats::JsonFormat)
+    def initialize(site, format: ActiveResource::Formats::JsonFormat, logger: nil)
       raise ArgumentError, 'Missing site URI' unless site
       @proxy = @user = @password = nil
       self.site = site
       self.format = format
-    end
-
-    # defaults to ActiveResource::Base.logger
-    def logger
-      self.class.logger
+      self.logger = logger
     end
 
     # Set URI for remote service.

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -32,6 +32,17 @@ class ConnectionTest < ActiveSupport::TestCase
     end
   end
 
+  def test_same_logger_as_base
+    old_logger = ActiveResource::Base.logger
+    connection = new_connection
+    assert_equal connection.logger, old_logger
+
+    ActiveResource::Base.logger = Logger.new(STDOUT)
+    assert_equal new_connection.logger, ActiveResource::Base.logger
+  ensure
+    ActiveResource::Base.logger = old_logger
+  end
+
   def test_handle_response
     # 2xx and 3xx are valid responses.
     [200, 299, 300, 399].each do |code|

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -34,13 +34,15 @@ class ConnectionTest < ActiveSupport::TestCase
 
   def test_same_logger_as_base
     old_logger = ActiveResource::Base.logger
-    connection = new_connection
-    assert_equal connection.logger, old_logger
+    old_site = ActiveResource::Base.site
+    ActiveResource::Base.site = 'http://localhost'
+    assert_equal old_logger, ActiveResource::Base.connection.logger
 
     ActiveResource::Base.logger = Logger.new(STDOUT)
-    assert_equal new_connection.logger, ActiveResource::Base.logger
+    assert_equal ActiveResource::Base.logger, ActiveResource::Base.connection.logger
   ensure
     ActiveResource::Base.logger = old_logger
+    ActiveResource::Base.site = old_site
   end
 
   def test_handle_response


### PR DESCRIPTION
Adds a `logger` method to `ActiveResource::Connection`, which
defaults to `ActiveResource::Base.logger`. The idea is that instead of using `ActiveResource::Base`'s logger directly, you use the connection's logger, so that subclasses and user code can override which logger is used. For example:

```
class ShopifyAPI::Connection < ActiveResource::Connection
  def self.logger
    ShopifyAPI::Base.logger
  end

  # ...
end
```