### PR TITLE
ActiveResource::Base#exists? Convert response code to integer for include check

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1003,7 +1003,7 @@ module ActiveResource
           prefix_options, query_options = split_options(options[:params])
           path = element_path(id, prefix_options, query_options)
           response = connection.head(path, headers)
-          (200..206).include? response.code
+          (200..206).include? response.code.to_i
         end
         # id && !find_single(id, options).nil?
       rescue ActiveResource::ResourceNotFound, ActiveResource::ResourceGone


### PR DESCRIPTION
Some clients that use ActiveResource have response codes returned as strings which makes the `.exists?` method always return false.
Encountered this issue specifically while using the shopify_api gem.
 (https://github.com/Shopify/shopify_api)

This fix brings back the conversion to integer that was lost by the following PR: https://github.com/rails/activeresource/pull/145

I wasn't able to add a test, because as far as I know, the HttpMock converts the status to integer which would make the test not valid.