### PR TITLE
Allow variable ConnectionClass identical to 5.0

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -305,6 +305,8 @@ module ActiveResource
     class_attribute :include_format_in_path
     self.include_format_in_path = true
 
+    class_attribute :connection_class
+    self.connection_class = Connection
 
     class << self
       include ThreadsafeAttributes
@@ -632,7 +634,7 @@ module ActiveResource
       # or not (defaults to <tt>false</tt>).
       def connection(refresh = false)
         if _connection_defined? || superclass == Object
-          self._connection = Connection.new(site, format) if refresh || _connection.nil?
+          self._connection = connection_class.new(site, format) if refresh || _connection.nil?
           _connection.proxy = proxy if proxy
           _connection.user = user if user
           _connection.password = password if password


### PR DESCRIPTION
Added class_attribute :connection_class, exactly identical to the code provided in version 5.0. However this is needed for compatibility with applications running Rails 4.x. Making a 4.1.1 version would be an acceptable solution and would provide to be of great use by others.