### PR TITLE
Match the log level to the HTTP response code for easier troubleshooting

### DIFF
--- a/lib/active_resource/log_subscriber.rb
+++ b/lib/active_resource/log_subscriber.rb
@@ -2,8 +2,11 @@ module ActiveResource
   class LogSubscriber < ActiveSupport::LogSubscriber
     def request(event)
       result = event.payload[:result]
-      info "#{event.payload[:method].to_s.upcase} #{event.payload[:request_uri]}"
-      info "--> %d %s %d (%.1fms)" % [result.code, result.message, result.body.to_s.length, event.duration]
+
+      log_level_method = result.code.to_i < 400 ? :info : :error
+
+      send log_level_method, "#{event.payload[:method].to_s.upcase} #{event.payload[:request_uri]}"
+      send log_level_method, "--> %d %s %d (%.1fms)" % [result.code, result.message, result.body.to_s.length, event.duration]
     end
 
     def logger


### PR DESCRIPTION
We've been using this code in a monkey patch and think it might benefit others.

The ActiveResource logging is a phenomenal tool; however, I think it's a little too verbose. In our case, we put more value on requests that fail and want more detail in these cases only. This change allows us to configure more strict logging in our applications and still capture the relevant failure cases for future troubleshooting.