### PR TITLE
Custom option for find path

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -672,6 +672,12 @@ module ActiveResource
         @collection_name ||= ActiveSupport::Inflector.pluralize(element_name)
       end
 
+      attr_writer :find_method
+
+      def find_method
+        @find_method ||= ''
+      end
+
       attr_writer :primary_key
 
       def primary_key
@@ -759,11 +765,14 @@ module ActiveResource
       #   Comment.element_path(1, {:post_id => 5}, {:active => 1})
       #   # => /posts/5/comments/1.json?active=1
       #
-      def element_path(id, prefix_options = {}, query_options = nil)
+      #   Comment.element_path(1, {:post_id => 5}, {:active => 1}, '/detail')
+      #   # => /posts/5/comments/1/detail.json?active=1
+      #
+      def element_path(id, prefix_options = {}, query_options = nil, method_name = nil)
         check_prefix_options(prefix_options)
 
         prefix_options, query_options = split_options(prefix_options) if query_options.nil?
-        "#{prefix(prefix_options)}#{collection_name}/#{URI.parser.escape id.to_s}#{format_extension}#{query_string(query_options)}"
+        "#{prefix(prefix_options)}#{collection_name}/#{URI.parser.escape id.to_s}#{method_name}#{format_extension}#{query_string(query_options)}"
       end
 
       # Gets the new element path for REST resources.
@@ -1054,7 +1063,7 @@ module ActiveResource
         # Find a single resource from the default URL
         def find_single(scope, options)
           prefix_options, query_options = split_options(options[:params])
-          path = element_path(scope, prefix_options, query_options)
+          path = element_path(scope, prefix_options, query_options, find_method)
           instantiate_record(format.decode(connection.get(path, headers).body), prefix_options)
         end
 

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -11,6 +11,7 @@ require "fixtures/post"
 require "fixtures/comment"
 require "fixtures/product"
 require "fixtures/inventory"
+require "fixtures/item"
 require 'active_support/json'
 require 'active_support/core_ext/hash/conversions'
 require 'mocha/setup'
@@ -733,6 +734,10 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal '/people/1/addresses/1.json?type=work', StreetAddress.element_path(1, {:person_id => 1}, {:type => 'work'})
   end
 
+  def test_custom_element_path_with_method_name
+    assert_equal '/items/1/detail.json', Item.element_path(1, {}, nil, '/detail')
+  end
+
   def test_custom_collection_path_without_required_prefix_param
     assert_raise ActiveResource::MissingPrefixParam do
       StreetAddress.collection_path
@@ -804,6 +809,16 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal [:person_id].to_set, StreetAddress.__send__(:prefix_parameters)
   end
 
+  def test_find_method
+    assert_equal '/detail', Item.find_method
+  end
+
+  def test_set_find_method
+    SetterTrap.rollback_sets(Item) do |item_class|
+      item_class.find_method = '/show'
+      assert_equal '/show', item_class.find_method
+    end
+  end
 
   ########################################################################
   # Tests basic CRUD functions (find/save/create etc)
@@ -1507,5 +1522,9 @@ class BaseTest < ActiveSupport::TestCase
 
   ensure
     ActiveResource::Base.include_format_in_path = true
+  end
+
+  def test_custom_find_path
+    assert_equal "/items/1/detail.json", Item.element_path(1, {}, nil, "/detail")
   end
 end

--- a/test/fixtures/item.rb
+++ b/test/fixtures/item.rb
@@ -1,0 +1,4 @@
+class Item < ActiveResource::Base
+  self.site = "http://37s.sunrise.i:3000"
+  self.find_method = '/detail'
+end


### PR DESCRIPTION
Issue: #267

When NOT RESTful API path, such as `GET /posts/:id/detail.json`,
I write the followings,

```ruby
Item.find(:one, from: '/posts/1/detail.json')
``` 

But, I want to write `Item.find(1)`.