### PR TITLE
Update API documentation link to version 5.0.0

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -245,9 +245,9 @@ See {CONTRIBUTING}[https://github.com/rails/activeresource/blob/master/CONTRIBUT
 
 == Support
 
-API documentation is at
+Current API documentation is at
 
-* http://rubydoc.info/gems/activeresource/4.0.0/frames
+* http://rubydoc.info/gems/activeresource/5.0.0/frames
 
 Bug reports and feature requests can be filed with the rest for the Ruby on Rails project here:
 


### PR DESCRIPTION
# Summary
* This PR updates README's API documentation link to version 5.0.0.