### PR TITLE
The logger nows logs a synthetic '523' error. Fix 150

### DIFF
--- a/lib/active_resource/log_subscriber.rb
+++ b/lib/active_resource/log_subscriber.rb
@@ -3,10 +3,16 @@ module ActiveResource
     def request(event)
       result = event.payload[:result]
 
-      log_level_method = result.code.to_i < 400 ? :info : :error
+      # When result is nil, the connection could not even be initiated
+      # with the server, so we log an internal synthetic error response (523).
+      code    = result.try(:code)    || 523  # matches CloudFlare's convention
+      message = result.try(:message) || "ActiveResource connection error"
+      body    = result.try(:body)    || ""
+
+      log_level_method = code.to_i < 400 ? :info : :error
 
       send log_level_method, "#{event.payload[:method].to_s.upcase} #{event.payload[:request_uri]}"
-      send log_level_method, "--> %d %s %d (%.1fms)" % [result.code, result.message, result.body.to_s.length, event.duration]
+      send log_level_method, "--> %d %s %d (%.1fms)" % [code, message, body.to_s.length, event.duration]
     end
 
     def logger

--- a/test/cases/log_subscriber_test.rb
+++ b/test/cases/log_subscriber_test.rb
@@ -49,4 +49,13 @@ class LogSubscriberTest < ActiveSupport::TestCase
     assert_equal 'GET http://37s.sunrise.i:3000/people/3.json', @logger.logged(:error)[0]
     assert_match(/\-\-\> 502 502 0/, @logger.logged(:error)[1])
   end
+
+  def test_connection_failure
+    Person.find(99)
+  rescue
+    wait
+    assert_equal 2, @logger.logged(:error).size
+    assert_equal 'GET http://37s.sunrise.i:3000/people/99.json', @logger.logged(:error)[0]
+    assert_match(/\-\-\> 523 ActiveResource connection error 0/, @logger.logged(:error)[1])
+  end
 end


### PR DESCRIPTION
When connection can't even be established, the logger
gets a nil result; this used to raise an exception and
dump a lot of stack traces. This patch makes the logger
proceed without raising the exception; instead it logs
the following message:

  523 "ActiveResource connection error"

The 523 error code was chosen to match the closest
situation I can think of to describe the event (it's
a CloudFlare code), since really this error situation
occurs completely outside of the HTTP protocol anyway.