### PR TITLE
Add ActiveJob serialization support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 branch = ENV.fetch('BRANCH', 'master')
 gem 'activesupport', github: 'rails/rails', branch: branch
 gem 'activemodel', github: 'rails/rails', branch: branch
+gem 'activejob', github: 'rails/rails', branch: branch
 
 gemspec
 

--- a/lib/active_resource/active_job_serializer.rb
+++ b/lib/active_resource/active_job_serializer.rb
@@ -1,0 +1,24 @@
+module ActiveResource
+  class ActiveJobSerializer < ActiveJob::Serializers::ObjectSerializer
+    def serialize(resource)
+      super(
+        "class" => resource.class.name,
+        "persisted" => resource.persisted?,
+        "prefix_options" => resource.prefix_options.as_json,
+        "attributes" => resource.attributes.as_json
+      )
+    end
+
+    def deserialize(hash)
+      hash["class"].constantize.new(hash["attributes"]).tap do |resource|
+        resource.persisted      = hash["persisted"]
+        resource.prefix_options = hash["prefix_options"]
+      end
+    end
+
+    private
+      def klass
+        ActiveResource::Base
+      end
+  end
+end

--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -10,6 +10,12 @@ module ActiveResource
         ActiveResource::Base.send "#{k}=", v
       end
     end
+
+    initializer "active_resource.add_active_job_serializer" do |app|
+      if defined? app.config.active_job.custom_serializers
+        require "active_resource/active_job_serializer"
+        app.config.active_job.custom_serializers << ActiveResource::ActiveJobSerializer
+      end
+    end
   end
 end
-

--- a/test/cases/active_job_serializer_test.rb
+++ b/test/cases/active_job_serializer_test.rb
@@ -1,0 +1,52 @@
+require 'abstract_unit'
+
+require 'fixtures/project'
+require 'fixtures/person'
+require 'fixtures/product'
+require 'active_job'
+require 'active_job/arguments'
+require 'active_resource/active_job_serializer' if ActiveJob::VERSION::MAJOR >= 6
+
+class ActiveJobSerializerTest < ActiveSupport::TestCase
+
+  setup do
+    @klass = ActiveResource::ActiveJobSerializer
+  end
+
+  def test_serialize
+    project = Project.new(id: 1, name: 'Ruby on Rails')
+    project.prefix_options[:person_id] = 1
+    project_json = {
+      _aj_serialized: @klass.name,
+      class: project.class.name,
+      persisted: project.persisted?,
+      prefix_options: project.prefix_options,
+      attributes: project.attributes
+    }.as_json
+    serialized_json = @klass.serialize(project)
+
+    assert_equal project_json, serialized_json
+  end
+
+  def test_deserialize
+    person = Person.new(id: 2, name: 'David')
+    person.persisted = true
+    person_json = {
+      _aj_serialized: @klass.name,
+      class: person.class.name,
+      persisted: person.persisted?,
+      prefix_options: person.prefix_options,
+      attributes: person.attributes
+    }.as_json
+    deserialized_object = @klass.deserialize(person_json)
+
+    assert_equal person, deserialized_object
+  end
+
+  def test_serialize?
+    product = Product.new(id: 3, name: 'Chunky Bacon')
+
+    assert @klass.serialize?(product)
+    refute @klass.serialize?('not a resource')
+  end
+end if ActiveJob::VERSION::MAJOR >= 6


### PR DESCRIPTION
Currently, `ActiveResource` objects are not serializable by `ActiveJob`. This PR makes active resource objects serializable by default so no custom serializers or monkey patching is required.