### PR TITLE
Allow custom json body

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -41,6 +41,10 @@ that inherits from ActiveResource::Base and providing a <tt>site</tt> class vari
 
    class Person < ActiveResource::Base
      self.site = "http://api.people.com:3000"
+     self.include_format_in_path = false # If your API doesn't support the format in the URL
+     # If your json has main key which has the items list, for example :
+     # { 'status': 200, 'data': [ {item1}, {item2}, {item2} ] }
+     self.response_array_key = 'data'
    end
 
 Now the Person class is REST enabled and can invoke REST services very similarly to how Active Record invokes

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1067,11 +1067,11 @@ module ActiveResource
               instantiate_collection(get(from, options[:params]), options[:params])
             when String
               path = "#{from}#{query_string(options[:params])}"
-              instantiate_collection(format.decode(connection.get(path, headers).body) || [], options[:params])
+              instantiate_collection(format.decode(connection.get(path, headers).body, connection.response_array_key) || [], options[:params])
             else
               prefix_options, query_options = split_options(options[:params])
               path = collection_path(prefix_options, query_options)
-              instantiate_collection( (format.decode(connection.get(path, headers).body) || []), query_options, prefix_options )
+              instantiate_collection( (format.decode(connection.get(path, headers).body, connection.response_array_key) || []), query_options, prefix_options )
             end
           rescue ActiveResource::ResourceNotFound
             # Swallowing ResourceNotFound exceptions and return nil - as per
@@ -1087,7 +1087,7 @@ module ActiveResource
             instantiate_record(get(from, options[:params]))
           when String
             path = "#{from}#{query_string(options[:params])}"
-            instantiate_record(format.decode(connection.get(path, headers).body))
+            instantiate_record(format.decode(connection.get(path, headers).body, connection.response_array_key))
           end
         end
 
@@ -1095,7 +1095,7 @@ module ActiveResource
         def find_single(scope, options)
           prefix_options, query_options = split_options(options[:params])
           path = element_path(scope, prefix_options, query_options)
-          instantiate_record(format.decode(connection.get(path, headers).body), prefix_options)
+          instantiate_record(format.decode(connection.get(path, headers).body, connection.response_array_key), prefix_options)
         end
 
         def instantiate_collection(collection, original_params = {}, prefix_options = {})
@@ -1563,7 +1563,7 @@ module ActiveResource
         if (response_code_allows_body?(response.code) &&
             (response['Content-Length'].nil? || response['Content-Length'] != "0") &&
             !response.body.nil? && response.body.strip.size > 0)
-          load(self.class.format.decode(response.body), true, true)
+          load(self.class.format.decode(response.body, connection.response_array_key), true, true)
           @persisted = true
         end
       end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -319,7 +319,7 @@ module ActiveResource
     class << self
       include ThreadsafeAttributes
       threadsafe_attribute :_headers, :_connection, :_user, :_password, :_site,
-                           :_proxy, :response_array_key
+                           :_proxy
 
       # Creates a schema for this resource - setting the attributes that are
       # known prior to fetching an instance from the remote system.

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -310,6 +310,7 @@ module ActiveResource
     class_attribute :_format
     class_attribute :_collection_parser
     class_attribute :include_format_in_path
+    class_attribute :response_array_key
     self.include_format_in_path = true
 
     class_attribute :connection_class
@@ -317,7 +318,8 @@ module ActiveResource
 
     class << self
       include ThreadsafeAttributes
-      threadsafe_attribute :_headers, :_connection, :_user, :_password, :_site, :_proxy
+      threadsafe_attribute :_headers, :_connection, :_user, :_password, :_site,
+                           :_proxy, :response_array_key
 
       # Creates a schema for this resource - setting the attributes that are
       # known prior to fetching an instance from the remote system.
@@ -651,6 +653,7 @@ module ActiveResource
           _connection.timeout = timeout if timeout
           _connection.open_timeout = open_timeout if open_timeout
           _connection.read_timeout = read_timeout if read_timeout
+          _connection.response_array_key = response_array_key if response_array_key
           _connection.ssl_options = ssl_options if ssl_options
           _connection
         else

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -150,14 +150,6 @@ module ActiveResource
           when 301, 302, 303, 307
             raise(Redirection.new(response))
           when 200...400
-            unless @response_array_key.blank?
-              begin
-                new_response_body = ActiveSupport::JSON.decode(response.body)[@response_array_key]
-                response.body = ActiveSupport::JSON.encode(new_response_body)
-              rescue Exception => e
-                @logger.error 'Failed to parse json' if @logger
-              end
-            end
             response
           when 400
             raise(BadRequest.new(response))

--- a/lib/active_resource/formats/json_format.rb
+++ b/lib/active_resource/formats/json_format.rb
@@ -17,9 +17,10 @@ module ActiveResource
         ActiveSupport::JSON.encode(hash, options)
       end
 
-      def decode(json)
+      def decode(json, response_array_key = nil)
         return nil if json.nil?
-        Formats.remove_root(ActiveSupport::JSON.decode(json))
+        return Formats.remove_root(ActiveSupport::JSON.decode(json)) if response_array_key.nil?
+        Formats.remove_root(ActiveSupport::JSON.decode(json)[response_array_key])
       end
     end
   end

--- a/lib/active_resource/formats/xml_format.rb
+++ b/lib/active_resource/formats/xml_format.rb
@@ -17,7 +17,7 @@ module ActiveResource
         hash.to_xml(options)
       end
 
-      def decode(xml)
+      def decode(xml, response_array_key = nil)
         Formats.remove_root(Hash.from_xml(xml))
       end
     end

--- a/test/fixtures/address.rb
+++ b/test/fixtures/address.rb
@@ -2,7 +2,7 @@
 class AddressXMLFormatter
   include ActiveResource::Formats::XmlFormat
 
-  def decode(xml)
+  def decode(xml, response_array_key = nil)
     data = ActiveResource::Formats::XmlFormat.decode(xml)
     # process address fields
     data.each do |address|


### PR DESCRIPTION
Some `APIs` doesn't follow the known standards and they're returning the json array or the json object inside a key for example : 
```json
{
    "status": 200,
    "data": [
      {
          "id": 1,
          "active": true
      },
      {
          "id": 2,
          "active": false
      }
    ]
}

```

And now ActiveResource doesn't understand these APIs so I added an optional attribute called `response_array_key` you can set its value inside the `ActiveResource` model to solve this issue.
So now if you added `self.response_array_key = 'data'` to your `ActiveResource` model it will understand your API and if you left it empty nothing will happen.

