### PR TITLE
Support lazy setting of config options

### DIFF
--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -6,8 +6,10 @@ module ActiveResource
     config.active_resource = ActiveSupport::OrderedOptions.new
 
     initializer "active_resource.set_configs" do |app|
-      app.config.active_resource.each do |k,v|
-        ActiveResource::Base.send "#{k}=", v
+      ActiveSupport.on_load(:active_resource) do
+        app.config.active_resource.each do |k,v|
+          send "#{k}=", v
+        end
       end
     end
 


### PR DESCRIPTION
Similar to how the rest of Rails gained lazy config initialization
https://github.com/rails/rails/commit/39d6f9e112f2320d8c2006ee3bcc160cfa761d0a
which was later refactored to leverage framework-wide on_load hook
https://github.com/rails/rails/commit/4aded43b73ff94dbf06b4a2d2075651ce454e1d5
, ActiveResource now lazily applies configuration options from the
railtie. This allows active_resource config settings to be set within
`Rails.application.configure` block from an initializer file.

Prior to this change, ActiveResource's `set_configs` initializer ran
prior to an application's initializer file.

closes #288