### PR TITLE
use UnknownResource when resource fails to create normally

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1621,24 +1621,22 @@ module ActiveResource
 
         const_args = [resource_name, false]
 
-        if const_valid?(*const_args)
-          if self.class.const_defined?(*const_args)
-            self.class.const_get(*const_args)
+        if !const_valid?(*const_args)
+          # resource_name is not a valid ruby module name and cannot be created normally
+           find_or_create_resource_for(:UnnamedResource)
+        elsif self.class.const_defined?(*const_args)
+          self.class.const_get(*const_args)
+        else
+          ancestors = self.class.name.to_s.split("::")
+          if ancestors.size > 1
+            find_or_create_resource_in_modules(resource_name, ancestors)
           else
-            ancestors = self.class.name.to_s.split("::")
-            if ancestors.size > 1
-              find_or_create_resource_in_modules(resource_name, ancestors)
+            if Object.const_defined?(*const_args)
+              Object.const_get(*const_args)
             else
-              if Object.const_defined?(*const_args)
-                Object.const_get(*const_args)
-              else
-                create_resource_for(resource_name)
-              end
+              create_resource_for(resource_name)
             end
           end
-        else
-          # resource_name was not a valid ruby module name and cannot be created normally
-          find_or_create_resource_for(:UnnamedResource)
         end
       end
 

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1621,7 +1621,7 @@ module ActiveResource
 
         const_args = [resource_name, false]
 
-        begin
+        if const_valid?(*const_args)
           if self.class.const_defined?(*const_args)
             self.class.const_get(*const_args)
           else
@@ -1636,10 +1636,17 @@ module ActiveResource
               end
             end
           end
-        rescue NameError
+        else
           # resource_name was not a valid ruby module name and cannot be created normally
           find_or_create_resource_for(:UnknownResource)
         end
+      end
+
+      def const_valid?(*const_args)
+        self.class.const_defined?(*const_args)
+        true
+      rescue NameError
+        false
       end
 
       # Create and return a class definition for a resource inside the current resource

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1638,7 +1638,7 @@ module ActiveResource
           end
         else
           # resource_name was not a valid ruby module name and cannot be created normally
-          find_or_create_resource_for(:UnknownResource)
+          find_or_create_resource_for(:UnnamedResource)
         end
       end
 

--- a/test/cases/base/load_test.rb
+++ b/test/cases/base/load_test.rb
@@ -107,8 +107,8 @@ class BaseLoadTest < ActiveSupport::TestCase
     Person.__send__(:remove_const, :Books) if Person.const_defined?(:Books)
     assert !Person.const_defined?(:Books), "Books shouldn't exist until autocreated"
     assert_nothing_raised{@person.load(@complex_books)}
-    assert Person::Books.const_defined?(:UnknownResource), "UnknownResource should have been autocreated"
-    @person.books.attributes.keys.each { |key| assert_kind_of Person::Books::UnknownResource, @person.books.attributes[key] }
+    assert Person::Books.const_defined?(:UnnamedResource), "UnnamedResource should have been autocreated"
+    @person.books.attributes.keys.each { |key| assert_kind_of Person::Books::UnnamedResource, @person.books.attributes[key] }
   end
 
   def test_load_expects_hash

--- a/test/cases/base/load_test.rb
+++ b/test/cases/base/load_test.rb
@@ -1,6 +1,5 @@
 require 'abstract_unit'
 require "fixtures/person"
-require 'fixtures/post'
 require "fixtures/street_address"
 require 'active_support/core_ext/hash/conversions'
 
@@ -90,17 +89,23 @@ class BaseLoadTest < ActiveSupport::TestCase
     @person = Person.new
   end
 
-  def test_load_hash_with_integers_as_keys
-    assert_nothing_raised{@person.load(@books)}
+  def test_load_hash_with_integers_as_keys_creates_stringified_attributes
+    Person.__send__(:remove_const, :Book) if Person.const_defined?(:Book)
+    assert !Person.const_defined?(:Book), "Books shouldn't exist until autocreated"
+    assert_nothing_raised{ @person.load(@books) }
+    assert_equal @books[:books].map{ |book| book.stringify_keys }, @person.books.map(&:attributes)
   end
 
-  def test_load_hash_with_dates_as_keys
+  def test_load_hash_with_dates_as_keys_creates_stringified_attributes
+    Person.__send__(:remove_const, :Book) if Person.const_defined?(:Book)
+    assert !Person.const_defined?(:Book), "Books shouldn't exist until autocreated"
     assert_nothing_raised{@person.load(@books_date)}
+    assert_equal @books_date[:books].map{ |book| book.stringify_keys }, @person.books.map(&:attributes)
   end
 
   def test_load_hash_with_unacceptable_constant_characters_creates_unknown_resource
     Person.__send__(:remove_const, :Books) if Person.const_defined?(:Books)
-    assert !Person.const_defined?(:Books), "books shouldn't exist until autocreated"
+    assert !Person.const_defined?(:Books), "Books shouldn't exist until autocreated"
     assert_nothing_raised{@person.load(@complex_books)}
     assert Person::Books.const_defined?(:UnknownResource), "UnknownResource should have been autocreated"
     @person.books.attributes.keys.each { |key| assert_kind_of Person::Books::UnknownResource, @person.books.attributes[key] }


### PR DESCRIPTION
When loading a resource, checking if the key responds to `to_sym` is
insufficient to ensure a valid resource is created. An integer like
1234 will not respond to `to_sym` but "1234" will. Attempting to
check const_defined? for "1234" will result in a "NameError: wrong
constant name 1234"

Similarly, any string with special characters or spaces will error as
well.

Instead, this stops checking for symbols in Base#split_options and will
catch the NameError exception should it arise and create a resource
called UnknownResource instead which will hold the resource attributes.


For example, if a response comes back like this:

```json
{
  "refunds": [
          {
                "id": 20424848300,
                "transactions": [
                    {
                        "receipt": {
                            "card_transaction": {
                                "status": "paid",
                                "amount": "98.87",
                                "currency": "EUR"
                            },
                            "card_details": {
                                "type": "Amex"
                            },
                            "discount_details": {
                                "2FOR99": {
                                    "code": "2FOR99",
                                    "amount": "32.00"
                                }
                            }
                        },
                    }
                ]
          }
      ]
}
```

the key "2FOR99" will error out. With this change, we will get a resource created `Refunds::Transactions::Receipt::DiscountDetails::UnknownResource` when trying to access `"2FOR99"` from under "discount_details" with all attributes intact. 


I wasn't sure of the absolute best way to handle this issue, so I also made a PR here https://github.com/rails/activeresource/pull/294 which replaces all dynamic resource creation so any unknown resource, regardless of if we can constantize it, will become UnnamedResource

