### PR TITLE
use UnnamedResource instead of creating a new resource

### DIFF
--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1382,11 +1382,11 @@ class BaseTest < ActiveSupport::TestCase
     luis = Customer.find(1)
     assert_kind_of Customer, luis
     luis.friends.each do |friend|
-      assert_kind_of Customer::Friend, friend
+      assert_kind_of Customer::UnnamedResource, friend
       friend.brothers.each do |brother|
-        assert_kind_of Customer::Friend::Brother, brother
+        assert_kind_of Customer::UnnamedResource::UnnamedResource, brother
         brother.children.each do |child|
-          assert_kind_of Customer::Friend::Brother::Child, child
+          assert_kind_of Customer::UnnamedResource::UnnamedResource::UnnamedResource, child
         end
       end
     end
@@ -1494,7 +1494,7 @@ class BaseTest < ActiveSupport::TestCase
 
   def test_namespacing
     sound = Asset::Sound.find(1)
-    assert_equal "Asset::Sound::Author", sound.author.class.to_s
+    assert_equal "Asset::Sound::UnnamedResource", sound.author.class.to_s
   end
 
   def test_paths_with_format


### PR DESCRIPTION
When loading a resource, checking if the key responds to `to_sym` is
insufficient to ensure a valid resource is created. An integer like
1234 will not respond to `to_sym` but "1234" will. Attempting to
check const_defined? for "1234" will result in a "NameError: wrong
constant name 1234"

Similarly, any string with special characters or spaces will error as
well.

This stops checking for symbols in Base#split_options and will and  for for every hash key returned, a class called UnnamedResource will be used to hold the resource attributes.

For example, if a response comes back like this:

```json
{
  "refunds": [
          {
                "id": 20424848300,
                "transactions": [
                    {
                        "receipt": {
                            "card_transaction": {
                                "status": "paid",
                                "amount": "98.87",
                                "currency": "EUR"
                            },
                            "card_details": {
                                "type": "Amex"
                            },
                            "discount_details": {
                                "2FOR99": {
                                    "code": "2FOR99",
                                    "amount": "32.00"
                                }
                            }
                        },
                    }
                ]
          }
      ]
}
```

the key "2FOR99" will error out. With this change, assuming we have a class for `Refund` and `Transactions` inheriting from `ActiveResource::Base`  we will get a resource created `Refunds::Transactions::UnnamedResource::UnnamedResource::UnnamedResource`  when trying to access `"2FOR99"` from under "discount_details" with all attributes intact. 

@rafaelfranca you mentioned this might be the better solution as it would reduce the risk of running into unbound memory issues. I made another PR here https://github.com/rails/activeresource/pull/293 that only uses a built in resource if ActiveResource throws an exception. It won't do anything for memory, but I think its less likely to disrupt existing code bases. 


