### PR TITLE
response_code_allows_body? expects a number

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1557,7 +1557,7 @@ module ActiveResource
       end
 
       def load_attributes_from_response(response)
-        if (response_code_allows_body?(response.code) &&
+        if (response_code_allows_body?(response.code.to_i) &&
             (response['Content-Length'].nil? || response['Content-Length'] != "0") &&
             !response.body.nil? && response.body.strip.size > 0)
           load(self.class.format.decode(response.body), true, true)


### PR DESCRIPTION
`response_code_allows_body?` checks to see if the response status code is in the ranges of codes that do not have response bodies. However, the function is comparing to integer ranges whereas `response.code` is a string. This _appears_ to be the only remaining instance where status code is not properly converted to_i.

Others were fixed: 9c685ebf91ab74d8dffb3220ffbbf962b32f0c88
Or correct from the beginning: https://github.com/rails/activeresource/blame/0ae3010f505b5e6063b7acbcd22cc221995e7873/lib/active_resource/connection.rb#L143