### PR TITLE
Base Class Does Not Override Subclass Headers

### DIFF
--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -592,6 +592,32 @@ class BaseTest < ActiveSupport::TestCase
     assert_not_equal(first_connection, second_connection, 'Connection should be re-created')
   end
 
+  def test_header_should_be_overwritten_if_changed_in_base_class_within_module
+    code = <<-CODE
+      module TestModule
+        # Base class for ActiveResources
+        class Base < ActiveResource::Base
+          self.site = 'http://market'
+        end
+      end
+
+      module TestModule
+        class Fruit < Base
+        end
+      end
+    CODE
+
+    eval code
+
+    TestModule::Base.headers['Authorization'] = 'value1'
+    fruit = TestModule::Fruit
+    assert_equal 'value1', fruit.headers['Authorization']
+
+    TestModule::Base.headers['Authorization'] = 'value2'
+    fruit = TestModule::Fruit
+    assert_equal 'value2', fruit.headers['Authorization']
+  end
+
   def test_header_inheritance
     fruit = Class.new(ActiveResource::Base)
     apple = Class.new(fruit)


### PR DESCRIPTION
This PR adds a test to showcase the issue I experienced. Looking to get advice as to whether this is intended functionality and if so is there some documentation we can add that will help to not confuse future users.

Issue: https://github.com/rails/activeresource/issues/298