### PR TITLE
Bearer Token Authorization Header To Connection

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,6 +80,18 @@ Global Authentication to be used across all subclasses of ActiveResource::Base s
       self.connection.bearer_token = @bearer_token
     end
 
+ActiveResource supports 2 options for HTTP authentication today.
+
+1. Basic
+
+    ActiveResource::Connection.new("http://my%40email.com:%31%32%33@localhost")
+    # username: my@email.com password: 123
+
+2. Bearer Token
+
+    ActiveResource::Base.connection.auth_type = :bearer
+    ActiveResource::Base.connection.bearer_token = @bearer_token
+
 ==== Protocol
 
 Active Resource is built on a standard JSON or XML format for requesting and submitting resources over HTTP.  It mirrors the RESTful routing

--- a/README.rdoc
+++ b/README.rdoc
@@ -69,6 +69,16 @@ Active Resource supports the token based authentication provided by Rails throug
 You can also set any specific HTTP header using the same way.  As mentioned above, headers are thread-safe, so you can set headers dynamically, even in a multi-threaded environment:
 
     ActiveResource::Base.headers['Authorization'] = current_session_api_token
+    
+Global Authentication to be used across all subclasses of `ActiveResource::Base` should be handled using the `ActiveResource::Connection` class.
+
+    ActiveResource::Base.connection.auth_type = :bearer
+    ActiveResource::Base.connection.bearer_token = @bearer_token
+    
+    class Person < ActiveResource::Base
+      self.connection.auth_type = :bearer
+      self.connection.bearer_token = @bearer_token
+    end
 
 ==== Protocol
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -70,7 +70,7 @@ You can also set any specific HTTP header using the same way.  As mentioned abov
 
     ActiveResource::Base.headers['Authorization'] = current_session_api_token
     
-Global Authentication to be used across all subclasses of `ActiveResource::Base` should be handled using the `ActiveResource::Connection` class.
+Global Authentication to be used across all subclasses of ActiveResource::Base should be handled using the ActiveResource::Connection class.
 
     ActiveResource::Base.connection.auth_type = :bearer
     ActiveResource::Base.connection.bearer_token = @bearer_token

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -20,7 +20,7 @@ module ActiveResource
       :head => 'Accept'
     }
 
-    attr_reader :site, :user, :password, :auth_type, :timeout, :open_timeout, :read_timeout, :proxy, :ssl_options
+    attr_reader :site, :user, :password, :bearer_token, :auth_type, :timeout, :open_timeout, :read_timeout, :proxy, :ssl_options
     attr_accessor :format, :logger
 
     class << self
@@ -33,7 +33,7 @@ module ActiveResource
     # attribute to the URI for the remote resource service.
     def initialize(site, format = ActiveResource::Formats::JsonFormat, logger: nil)
       raise ArgumentError, 'Missing site URI' unless site
-      @proxy = @user = @password = nil
+      @proxy = @user = @password = @bearer_token = nil
       self.site = site
       self.format = format
       self.logger = logger
@@ -60,6 +60,11 @@ module ActiveResource
     # Sets the password for remote service.
     def password=(password)
       @password = password
+    end
+
+    # Sets the bearer token for remote service.
+    def bearer_token=(bearer_token)
+      @bearer_token = bearer_token
     end
 
     # Sets the auth type for remote service.
@@ -240,6 +245,8 @@ module ActiveResource
           else
             { 'Authorization' => 'Basic ' + ["#{@user}:#{@password}"].pack('m').delete("\r\n") }
           end
+        elsif @bearer_token
+          { 'Authorization' => "Bearer #{@bearer_token}" }
         else
           {}
         end
@@ -294,7 +301,7 @@ module ActiveResource
       def legitimize_auth_type(auth_type)
         return :basic if auth_type.nil?
         auth_type = auth_type.to_sym
-        auth_type.in?([:basic, :digest]) ? auth_type : :basic
+        auth_type.in?([:basic, :digest, :bearer]) ? auth_type : :basic
       end
   end
 end


### PR DESCRIPTION
Since subclasses of the base class `ActiveResource::Base` copy-on-read http request headers, there is no easy way to define and override Authorization headers across all subclasses between multiple requests. Basic and Digest Authorization headers have already been built into the `ActiveResource::Connection` class, this PR adds a third approach: Bearer Token. JWT has become a lot more popular over the past few years and I believe that others will benefit from this change.

Issue: https://github.com/rails/activeresource/issues/277#issuecomment-425964403
Thank you to @jeremy for coming up with this solution.