### PR TITLE
has_one must respect parent’s prefix when target is not a Singleton

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -167,7 +167,7 @@ module ActiveResource::Associations
       elsif reflection.klass.respond_to?(:singleton_name)
         instance_variable_set(ivar_name, reflection.klass.find(:params => {:"#{self.class.element_name}_id" => self.id}))
       else
-        instance_variable_set(ivar_name, reflection.klass.find(:one, :from => "/#{self.class.collection_name}/#{self.id}/#{method_name}#{self.class.format_extension}"))
+        instance_variable_set(ivar_name, reflection.klass.find(:one, :from => custom_method_element_url(method_name)))
       end
     end
   end

--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -140,9 +140,10 @@ def setup_response
     # sound
     mock.get    "/sounds/1.json",                {}, @startup_sound
     # post
-    mock.get    "/posts.json",                   {}, @posts
-    mock.get    "/posts/1.json",                 {}, @post
-    mock.get    "/posts/1/comments.json",        {}, @comments
+    mock.get    "/api/v3/posts.json",            {}, @posts
+    mock.get    "/api/v3/posts/1.json",          {}, @post
+    mock.get    "/api/v3/posts/1/comments.json", {}, @comments
+    mock.get    "/api/v3/posts/1/author.json",   {}, @matz
     # products
     mock.get '/products/1.json', {}, @product
     mock.get '/products/1/inventory.json', {}, @inventory

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1434,12 +1434,6 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   def test_parse_non_singleton_resource_with_has_one_makes_get_request_on_child_route
-    accepts = { 'Accept' => 'application/json' }
-    ActiveResource::HttpMock.respond_to do |mock|
-      mock.get '/posts/1.json', accepts, @post
-      mock.get '/posts/1/author.json', accepts, @matz
-    end
-
     Post.send(:has_one, :author, class_name: 'Person')
     post = Post.find(1)
     assert post.author.name == ActiveSupport::JSON.decode(@matz)['person']['name']

--- a/test/fixtures/comment.rb
+++ b/test/fixtures/comment.rb
@@ -1,3 +1,3 @@
 class Comment < ActiveResource::Base
-  self.site = "http://37s.sunrise.i:3000/posts/:post_id"
+  self.site = "http://37s.sunrise.i:3000/api/v3/posts/:post_id"
 end

--- a/test/fixtures/post.rb
+++ b/test/fixtures/post.rb
@@ -1,3 +1,3 @@
 class Post < ActiveResource::Base
-  self.site = "http://37s.sunrise.i:3000"
+  self.site = "http://37s.sunrise.i:3000/api/v3/"
 end


### PR DESCRIPTION
Consider a simple case when URLs are prefixed with API version:

```ruby
class ApplicationResource < ActiveResource::Base
  self.site = "https://api.quovo.com/v3"
  self.include_format_in_path = false
end

class Connection < ApplicationResource
  has_one :sync
end

class Sync < ApplicationResource
end
```

`connection = Connection.find(1)` fetches data from `https://api.quovo.com:443/v3/connections/1`.

`connection.sync` is expected to fetch from `https://api.quovo.com:443/v3/connections/1/sync` but before this fix it tries to fetch it from `https://api.quovo.com:443/connections/1/sync` (missing `/v3/` prefix) that isn’t correct.


I believe that the bug was introduced in https://github.com/rails/activeresource/pull/100.