### PR TITLE
Create PreconditionFailed (412) exception

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -202,6 +202,7 @@ module ActiveResource
   # * 405 - ActiveResource::MethodNotAllowed
   # * 409 - ActiveResource::ResourceConflict
   # * 410 - ActiveResource::ResourceGone
+  # * 412 - ActiveResource::PreconditionFailed
   # * 422 - ActiveResource::ResourceInvalid (rescued by save as validation errors)
   # * 401..499 - ActiveResource::ClientError
   # * 500..599 - ActiveResource::ServerError

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -151,6 +151,8 @@ module ActiveResource
           raise(ResourceConflict.new(response))
         when 410
           raise(ResourceGone.new(response))
+        when 412
+          raise(PreconditionFailed.new(response))
         when 422
           raise(ResourceInvalid.new(response))
         when 401...500

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -71,6 +71,10 @@ module ActiveResource
   class ResourceGone < ClientError # :nodoc:
   end
 
+  # 412 Precondition Failed
+  class PreconditionFailed < ClientError # :nodoc:
+  end
+
   # 5xx Server Error
   class ServerError < ConnectionError # :nodoc:
   end

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -89,6 +89,9 @@ class ConnectionTest < ActiveSupport::TestCase
     # 410 is a removed resource
     assert_response_raises ActiveResource::ResourceGone, 410
 
+    # 412 is a precondition failed
+    assert_response_raises ActiveResource::PreconditionFailed, 412
+
     # 422 is a validation error
     assert_response_raises ActiveResource::ResourceInvalid, 422
 


### PR DESCRIPTION
Incremental addition of a new exception class, `ActiveResource::PreconditionFailed`, for `412 Precondition Failed`, see [RFC 7232 - Conditional Requests - section 4.2](https://tools.ietf.org/html/rfc7232#section-4.2). 

Thank you!