### PR TITLE
Allow setting the bearer_token directly

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -69,15 +69,15 @@ Active Resource supports the token based authentication provided by Rails throug
 You can also set any specific HTTP header using the same way.  As mentioned above, headers are thread-safe, so you can set headers dynamically, even in a multi-threaded environment:
 
     ActiveResource::Base.headers['Authorization'] = current_session_api_token
-    
+
 Global Authentication to be used across all subclasses of ActiveResource::Base should be handled using the ActiveResource::Connection class.
 
-    ActiveResource::Base.connection.auth_type = :bearer
-    ActiveResource::Base.connection.bearer_token = @bearer_token
-    
+    ActiveResource::Base.auth_type = :bearer
+    ActiveResource::Base.bearer_token = @bearer_token
+
     class Person < ActiveResource::Base
-      self.connection.auth_type = :bearer
-      self.connection.bearer_token = @bearer_token
+      self.auth_type = :bearer
+      self.bearer_token = @bearer_token
     end
 
 ActiveResource supports 2 options for HTTP authentication today.
@@ -89,8 +89,8 @@ ActiveResource supports 2 options for HTTP authentication today.
 
 2. Bearer Token
 
-    ActiveResource::Base.connection.auth_type = :bearer
-    ActiveResource::Base.connection.bearer_token = @bearer_token
+    ActiveResource::Base.auth_type = :bearer
+    ActiveResource::Base.bearer_token = @bearer_token
 
 ==== Protocol
 

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -537,6 +537,19 @@ module ActiveResource
         @auth_type = auth_type
       end
 
+      def bearer_token
+        if defined?(@bearer_token)
+          @bearer_token
+        elsif superclass != Object
+          superclass.bearer_token
+        end
+      end
+
+      def bearer_token=(bearer_token)
+        self._connection = nil
+        @bearer_token = bearer_token
+      end
+
       # Sets the format that attributes are sent and received in from a mime type reference:
       #
       #   Person.format = :json
@@ -650,6 +663,7 @@ module ActiveResource
           _connection.proxy = proxy if proxy
           _connection.user = user if user
           _connection.password = password if password
+          _connection.bearer_token = bearer_token if bearer_token
           _connection.auth_type = auth_type if auth_type
           _connection.timeout = timeout if timeout
           _connection.open_timeout = open_timeout if open_timeout


### PR DESCRIPTION
Currently, when setting the site of a child class, the bearer token set in the superclass is lost since `site=` sets `self._connection` to `nil`.

By setting the bearer token on the ActiveResource class instead of its connection, this PR fixes this issue.