### PR TITLE
Adds TooManyRequests (429) exception

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -204,6 +204,7 @@ module ActiveResource
   # * 410 - ActiveResource::ResourceGone
   # * 412 - ActiveResource::PreconditionFailed
   # * 422 - ActiveResource::ResourceInvalid (rescued by save as validation errors)
+  # * 429 - ActiveResource::TooManyRequests
   # * 401..499 - ActiveResource::ClientError
   # * 500..599 - ActiveResource::ServerError
   # * Other - ActiveResource::ConnectionError

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -155,6 +155,8 @@ module ActiveResource
           raise(PreconditionFailed.new(response))
         when 422
           raise(ResourceInvalid.new(response))
+        when 429
+          raise(TooManyRequests.new(response))
         when 401...500
           raise(ClientError.new(response))
         when 500...600

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -75,6 +75,10 @@ module ActiveResource
   class PreconditionFailed < ClientError # :nodoc:
   end
 
+  # 429 Too Many Requests
+  class TooManyRequests < ClientError # :nodoc:
+  end
+
   # 5xx Server Error
   class ServerError < ConnectionError # :nodoc:
   end

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -95,6 +95,9 @@ class ConnectionTest < ActiveSupport::TestCase
     # 422 is a validation error
     assert_response_raises ActiveResource::ResourceInvalid, 422
 
+    # 429 is too many requests
+    assert_response_raises ActiveResource::TooManyRequests, 429
+
     # 4xx are client errors.
     [402, 499].each do |code|
       assert_response_raises ActiveResource::ClientError, code


### PR DESCRIPTION
Adds a new exception class, ActiveResource::TooManyRequests, for 429 Too Many Requests, see [RFC 6585 -Additional HTTP Status Codes - section 4.](https://tools.ietf.org/html/rfc6585#section-4) which subclasses ActiveResource::ClientError which would have been returned before.

As a parallel to https://github.com/rails/activeresource/pull/302

Cheers!