### PR TITLE
Refreshing Bearer Tokens After Expiry

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -537,6 +537,32 @@ module ActiveResource
         @auth_type = auth_type
       end
 
+      # Gets the callback for refreshing a token HTTP authentication
+      def auth_body
+        if defined?(@auth_body)
+          @auth_body
+        end
+      end
+
+      # Sets the callback for refreshing a token HTTP authentication
+      def auth_body=(auth_body)
+        self._connection = nil
+        @auth_body = auth_body
+      end
+
+      # Gets the authentication path for refreshing a token for authentication
+      def auth_path
+        if defined?(@auth_path)
+          @auth_path
+        end
+      end
+
+      # Gets the authentication path for refreshing a token HTTP authentication
+      def auth_path=(auth_path)
+        self._connection = nil
+        @auth_path = auth_path
+      end
+
       # Sets the format that attributes are sent and received in from a mime type reference:
       #
       #   Person.format = :json
@@ -655,6 +681,8 @@ module ActiveResource
           _connection.open_timeout = open_timeout if open_timeout
           _connection.read_timeout = read_timeout if read_timeout
           _connection.ssl_options = ssl_options if ssl_options
+          _connection.auth_path = auth_path if auth_path
+          _connection.auth_body = auth_body if auth_body
           _connection
         else
           superclass.connection

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -250,10 +250,10 @@ module ActiveResource
           { "Authorization" => @bearer_token || refresh_token }
         when :basic
           @user || @password ? { "Authorization" => "Basic " + ["#{@user}:#{@password}"].pack("m").delete("\r\n") } : {}
-        when :bearer_token
+        when :bearer
           @bearer_token ? { "Authorization" => "Bearer #{@bearer_token}" } : {}
         else
-          {}
+          @user || @password ? { "Authorization" => "Basic " + ["#{@user}:#{@password}"].pack("m").delete("\r\n") } : {}
         end
       end
 


### PR DESCRIPTION
I have attempted to add token refresh functionality to ActiveResource through the existing retry mechanism in `Connection.rb`.

You can now set an auth_type of `:jwt`, which makes an HTTP POST request to a user-set `auth_path` with a user-set 'auth_body' to attempt to get an updated JWT (JWT in our use case, it could be any refreshed bearer token, really).

What this looks like in my ActiveResource model:
```ruby

class Thing < ActiveResource::Base
  self.site = 'http://active-resource-service.com'
  self.auth_type = :jwt
  self.auth_body = -> { { email: '1982481+Eosis@users.noreply.github.com ', password: 'secrets123'}.to_json }
  self.auth_path = '/auth/login'
end

```

The existing tests all pass. I wanted to try and get some feedback prior to writing mocked up tests to test the new feature in the test suite. 😃 