### PR TITLE
Fix active job serializer railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Fix railtie logic that adds Active Job serialization support.
+
 ## Active Resource 5.1.0 (Nov 2, 2018) ##
 
 *   Improve support of Active Resource objects inside fibers.

--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -16,7 +16,7 @@ module ActiveResource
     end
 
     initializer "active_resource.add_active_job_serializer" do |app|
-      if defined? app.config.active_job.custom_serializers
+      if app.config.try(:active_job)&.custom_serializers
         require "active_resource/active_job_serializer"
         app.config.active_job.custom_serializers << ActiveResource::ActiveJobSerializer
       end


### PR DESCRIPTION
Fixes railtie code to automatically append `ActiveResource::ActiveJobSerializer` to custom serializers. Debugging this, it seems `defined? app.config.active_job.custom_serializers` returns `nil`, and doesn't actually add the serializer. Using `try(:active_job)` and then safe invocations seems like an acceptable alternative.