### PR TITLE
Remove ruby 2.4.5 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.4.5
   - 2.5.3
   - ruby-head
   - jruby-head


### PR DESCRIPTION
This is currently failing because of the decision for Rails 6 to require ruby 2.5+. I assume it is fine to remove runs against 2.4.x going forward.