### PR TITLE
Fix example in AR::Base.schema='s documentation

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -409,7 +409,7 @@ module ActiveResource
       # example:
       #
       #   class Person < ActiveResource::Base
-      #     schema = {'name' => :string, 'age' => :integer }
+      #     self.schema = {'name' => :string, 'age' => :integer }
       #   end
       #
       # The keys/values can be strings or symbols. They will be converted to


### PR DESCRIPTION
Just fixes an incorrect code example in `ActiveRecord::Base.schema=`'s inline documentation, was missing `self.`