### PR TITLE
Allow empty arrays in query parameters

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1130,7 +1130,12 @@ module ActiveResource
 
         # Builds the query string for the request.
         def query_string(options)
-          "?#{options.to_query}" unless options.nil? || options.empty?
+          return if options.nil? || options.empty?
+
+          # to_query strips out empty arrays
+          # Adding nil inside of the array fixes this
+          options = options.map { |k, v| v == [] ? [k, [nil]] : [k, v] }.to_h
+          "?#{options.to_query}"
         end
 
         # split an option hash into two hashes, one containing the prefix options,

--- a/test/cases/finder_test.rb
+++ b/test/cases/finder_test.rb
@@ -70,6 +70,12 @@ class FinderTest < ActiveSupport::TestCase
     assert_equal "David", people.first.name
   end
 
+  def test_where_with_clause_in_with_empty_array
+    ActiveResource::HttpMock.respond_to { |m| m.get "/people.json?id%5B%5D=", {}, '[]' }
+    people = Person.where(id: [])
+    assert_equal [], people
+  end
+
   def test_where_with_invalid_clauses
     error = assert_raise(ArgumentError) { Person.where(nil) }
     assert_equal "expected a clauses Hash, got nil", error.message


### PR DESCRIPTION
Although #141 is caused by `{id: []}.to_query` returning an empty string, according to https://github.com/rails/rails/pull/14949, this appears to be on purpose.

I discovered that `{id: [nil]}.to_query` returns `"id%5B%5D="` so my fix is to replace all empty array parameters with `[nil]` before calling `to_query`.

I'm definitely open to hearing other solutions, particularly because I understand this solution is somewhat of a hack.

Thanks!