### PR TITLE
Honor site path for has_one associations.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ git push origin my-feature-branch
 
 #### Make a Pull Request
 
-Go to https://github.com/rails/activeresource and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
+Go to https://github.com/contributor/activeresource and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
 
 #### Rebase
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ git push origin my-feature-branch
 
 #### Make a Pull Request
 
-Go to https://github.com/contributor/activeresource and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
+Go to https://github.com/rails/activeresource and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
 
 #### Rebase
 

--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -168,7 +168,7 @@ module ActiveResource::Associations
       elsif reflection.klass.respond_to?(:singleton_name)
         instance_variable_set(ivar_name, reflection.klass.find(params: { :"#{self.class.element_name}_id" => self.id }))
       else
-        instance_variable_set(ivar_name, reflection.klass.find(:one, from: "/#{self.class.collection_name}/#{self.id}/#{method_name}#{self.class.format_extension}"))
+        instance_variable_set(ivar_name, reflection.klass.find(:one, from: custom_method_element_url(method_name)))
       end
     end
   end

--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -40,6 +40,8 @@ def setup_response
   @post  = { id: 1, title: "Hello World", body: "Lorem Ipsum" }.to_json
   @posts = [{ id: 1, title: "Hello World", body: "Lorem Ipsum" }, { id: 2, title: "Second Post", body: "Lorem Ipsum" }].to_json
   @comments = [{ id: 1, post_id: 1, content: "Interesting post" }, { id: 2, post_id: 1, content: "I agree" }].to_json
+  @order = { id: 1 }.to_json
+  @shipping_label = { id: 1, order_id: 1 }.to_json
 
   # - deep nested resource -
   # - Luis (Customer)
@@ -148,6 +150,9 @@ def setup_response
     # products
     mock.get "/products/1.json", {}, @product
     mock.get "/products/1/inventory.json", {}, @inventory
+    # orders
+    mock.get "/api/v1/orders/1.json", {}, @order
+    mock.get "/api/v1/orders/1/shipping_label.json", {}, @shipping_label
   end
 
   Person.user = nil

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -13,6 +13,8 @@ require "fixtures/post"
 require "fixtures/comment"
 require "fixtures/product"
 require "fixtures/inventory"
+require "fixtures/order"
+require "fixtures/shipping_label"
 require "active_support/json"
 require "active_support/core_ext/hash/conversions"
 require "mocha/setup"
@@ -810,6 +812,14 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal [:person_id].to_set, StreetAddress.__send__(:prefix_parameters)
   end
 
+  def test_has_one_finder_uses_site_path
+    ShippingLabel.site = "http://37s.sunrise.i:3000/api/v1"
+    Order.site = "http://37s.sunrise.i:3000/api/v1"
+    Order.send(:has_one, :shipping_label)
+    order = Order.find(1)
+    order.expects(:custom_method_element_url).with(:shipping_label).returns("/api/v1/orders/1/shipping_label.json")
+    order.shipping_label
+  end
 
   ########################################################################
   # Tests basic CRUD functions (find/save/create etc)

--- a/test/fixtures/order.rb
+++ b/test/fixtures/order.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Order < ActiveResource::Base
+end

--- a/test/fixtures/shipping_label.rb
+++ b/test/fixtures/shipping_label.rb
@@ -1,0 +1,2 @@
+class ShippingLabel < ActiveResource::Base
+end


### PR DESCRIPTION
This fixes an issue where the site path would be incorrect for `has_one` relationships.

When the models were defined as:

```
class Order < ActiveResource::Base
  self.site = "http://example.com/api/v1"
  has_one :shipping_label
end

class ShippingLabel < ActiveResource::Base
  self.site = "http://example.com/api/v1"
end
```

The `/api/v1` portion of `site` would be stripped.

When doing:

```
Order.find(1).shipping_label
```

The URL used when doing a `get` for `shipping_label` would be `http://example.com/orders/1/shipping_label.json`, rather than `http://example.com/api/v1/orders/1/shipping_label.json`.

