### PR TITLE
Fix Rails 6.1 compatibility

### DIFF
--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -22,7 +22,7 @@ module ActiveResource
             add humanized_attributes[attr_name], message[(attr_name.size + 1)..-1]
           end
         end
-        self[:base] << message if attr_message.nil?
+        add(:base, message) if attr_message.nil?
       end
     end
 
@@ -40,11 +40,11 @@ module ActiveResource
           if @base.known_attributes.include?(key)
             add key, error
           elsif key == "base"
-            self[:base] << error
+            add(:base, error)
           else
             # reporting an error on an attribute not in attributes
             # format and add them to base
-            self[:base] << "#{key.humanize} #{error}"
+            add(:base, "#{key.humanize} #{error}")
           end
         end
       end


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from block in from_array at gems/activeresource-5.1.1/lib/active_resource/validations.rb:25)
```

@rafaelfranca @tenderlove @etiennebarrie @Edouard-chin 