### PR TITLE
Set frozen_string_literal: true in the generated code

### DIFF
--- a/lib/active_resource/schema.rb
+++ b/lib/active_resource/schema.rb
@@ -47,6 +47,7 @@ module ActiveResource # :nodoc:
       #   attr_names.each { |name| attribute(name, 'string', options) }
       # end
       class_eval <<-EOV, __FILE__, __LINE__ + 1
+        # frozen_string_literal: true
         def #{attr_type}(*args)
           options = args.extract_options!
           attr_names = args


### PR DESCRIPTION
Similar to: https://github.com/rails/rails/pull/38355

While memory profiling our application I noticed this:

```ruby
108  "string"
 99  /tmp/bundle/ruby/2.7.0/bundler/gems/activeresource-f9887f66be07/lib/active_resource/schema.rb:54
```

@rafaelfranca @tenderlove @etiennebarrie @Edouard-chin 