### PR TITLE
Stop using the deprecated URI.parser

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -44,8 +44,8 @@ module ActiveResource
     def site=(site)
       @site = site.is_a?(URI) ? site : URI.parse(site)
       @ssl_options ||= {} if @site.is_a?(URI::HTTPS)
-      @user = URI.parser.unescape(@site.user) if @site.user
-      @password = URI.parser.unescape(@site.password) if @site.password
+      @user = URI::DEFAULT_PARSER.unescape(@site.user) if @site.user
+      @password = URI::DEFAULT_PARSER.unescape(@site.password) if @site.password
     end
 
     # Set the proxy for remote service.
@@ -174,8 +174,8 @@ module ActiveResource
 
       def new_http
         if @proxy
-          user = URI.parser.unescape(@proxy.user) if @proxy.user
-          password = URI.parser.unescape(@proxy.password) if @proxy.password
+          user = URI::DEFAULT_PARSER.unescape(@proxy.user) if @proxy.user
+          password = URI::DEFAULT_PARSER.unescape(@proxy.password) if @proxy.password
           Net::HTTP.new(@site.host, @site.port, @proxy.host, @proxy.port, user, password)
         else
           Net::HTTP.new(@site.host, @site.port)


### PR DESCRIPTION
It's deprecated since https://github.com/rails/rails/pull/39733, but easily replaceable by `URI::DEFAULT_PARSER`.

@rafaelfranca 