### PR TITLE
Fix the missed URI.parser references

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -474,8 +474,8 @@ module ActiveResource
           self._site = nil
         else
           self._site = create_site_uri_from(site)
-          self._user = URI.parser.unescape(_site.user) if _site.user
-          self._password = URI.parser.unescape(_site.password) if _site.password
+          self._user = URI::DEFAULT_PARSER.unescape(_site.user) if _site.user
+          self._password = URI::DEFAULT_PARSER.unescape(_site.password) if _site.password
         end
       end
 
@@ -718,7 +718,7 @@ module ActiveResource
       # Default value is <tt>site.path</tt>.
       def prefix=(value = "/")
         # Replace :placeholders with '#{embedded options[:lookups]}'
-        prefix_call = value.gsub(/:\w+/) { |key| "\#{URI.parser.escape options[#{key}].to_s}" }
+        prefix_call = value.gsub(/:\w+/) { |key| "\#{URI::DEFAULT_PARSER.escape options[#{key}].to_s}" }
 
         # Clear prefix parameters in case they have been cached
         @prefix_parameters = nil


### PR DESCRIPTION
I made a mistake in https://github.com/rails/activeresource/pull/338, I forgot to save the `base.rb` file 🤦 

@rafaelfranca 