### PR TITLE
ActiveResource::ConnectionError#to_s to be able to have a message other than 'Failed.'

### DIFF
--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -10,7 +10,7 @@ module ActiveResource
     end
 
     def to_s
-      message = "Failed.".dup
+      message = @message || "Failed.".dup
       message << "  Response code = #{response.code}." if response.respond_to?(:code)
       message << "  Response message = #{response.message}." if response.respond_to?(:message)
       message


### PR DESCRIPTION
### ActiveResource::ConnectionError#to_s to be able to have a message other than 'Failed.'

An instance of AcrtiveResource::ConnentionError returns "Failed." when #message is called.
This happens even if the instance is initialized with any message.
If this behavior is right, I will close this PR.

- Before
```
ubuntu@ip-172-31-43-217:~/projects/myapp$ sudo bundle exec rails c
Loading development environment (Rails 6.0.3.2)
irb(main):001:0> e = ActiveResource::ConnectionError.new({}, "error")
irb(main):002:0> e
=> #<ActiveResource::ConnectionError: Failed.>
irb(main):003:0> e.message
=> "Failed."
```
- After
```
ubuntu@ip-172-31-43-217:~/projects/myapp$ sudo bundle exec rails c
Loading development environment (Rails 6.0.3.2)
irb(main):001:0> e = ActiveResource::ConnectionError.new({}, "error")
irb(main):002:0> e
=> #<ActiveResource::ConnectionError: error>
irb(main):003:0> e.message
=> "error"
```