### PR TITLE
Lambda token

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -237,7 +237,11 @@ module ActiveResource
             { "Authorization" => "Basic " + ["#{@user}:#{@password}"].pack("m").delete("\r\n") }
           end
         elsif @bearer_token
-          { "Authorization" => "Bearer #{@bearer_token}" }
+          if @bearer_token.is_a? Proc
+            { "Authorization" => "Bearer #{@bearer_token.call}" }
+          else
+            { "Authorization" => "Bearer #{@bearer_token}" }
+          end
         else
           {}
         end


### PR DESCRIPTION
Some tokens (like OAuth) need to be regenerated on every request. Passing a lambda instead of a constant string enables this.