### PR TITLE
Add support to set bearer token connection through Base class

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,7 +53,7 @@ life cycle methods that operate against a persistent store.
 As you can see, the methods are quite similar to Active Record's methods for dealing with database
 records.  But rather than dealing directly with a database record, you're dealing with HTTP resources (which may or may not be database records).
 
-Connection settings (`site`, `headers`, `user`, `password`, `proxy`) and the connections themselves are store in
+Connection settings (`site`, `headers`, `user`, `password`, `bearer_token`, `proxy`) and the connections themselves are store in
 thread-local variables to make them thread-safe, so you can also set these dynamically, even in a multi-threaded environment, for instance:
 
     ActiveResource::Base.site = api_site_for(request)
@@ -69,28 +69,24 @@ Active Resource supports the token based authentication provided by Rails throug
 You can also set any specific HTTP header using the same way.  As mentioned above, headers are thread-safe, so you can set headers dynamically, even in a multi-threaded environment:
 
     ActiveResource::Base.headers['Authorization'] = current_session_api_token
-    
-Global Authentication to be used across all subclasses of ActiveResource::Base should be handled using the ActiveResource::Connection class.
-
-    ActiveResource::Base.connection.auth_type = :bearer
-    ActiveResource::Base.connection.bearer_token = @bearer_token
-    
-    class Person < ActiveResource::Base
-      self.connection.auth_type = :bearer
-      self.connection.bearer_token = @bearer_token
-    end
 
 ActiveResource supports 2 options for HTTP authentication today.
 
 1. Basic
 
-    ActiveResource::Connection.new("http://my%40email.com:%31%32%33@localhost")
+    class Person < ActiveResource::Base
+      self.user = 'my@email.com'
+      self.password = '123'
+    end
     # username: my@email.com password: 123
 
 2. Bearer Token
 
-    ActiveResource::Base.connection.auth_type = :bearer
-    ActiveResource::Base.connection.bearer_token = @bearer_token
+    class Person < ActiveResource::Base
+      self.auth_type = :bearer
+      self.bearer_token = 'my-token123'
+    end
+    # Bearer my-token123
 
 ==== Protocol
 


### PR DESCRIPTION
Since ActiveResource::Connection accepts basic and bearer authorization attributes, ActiveResource::Base can also accept to set the `bearer_token` directly like `user` and `password` attributes.  

See issue #346 