### PR TITLE
Fix find_every instantiating records from symbol and string without prefix_options

### DIFF
--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -40,6 +40,7 @@ def setup_response
   @post  = { id: 1, title: "Hello World", body: "Lorem Ipsum" }.to_json
   @posts = [{ id: 1, title: "Hello World", body: "Lorem Ipsum" }, { id: 2, title: "Second Post", body: "Lorem Ipsum" }].to_json
   @comments = [{ id: 1, post_id: 1, content: "Interesting post" }, { id: 2, post_id: 1, content: "I agree" }].to_json
+  @pets = [{ id: 1, name: 'Max'}, { id: 2, name: 'Daisy'}].to_json
 
   # - deep nested resource -
   # - Luis (Customer)
@@ -148,6 +149,8 @@ def setup_response
     # products
     mock.get "/products/1.json", {}, @product
     mock.get "/products/1/inventory.json", {}, @inventory
+    #pets
+    mock.get "/people/1/pets.json", {}, @pets
   end
 
   Person.user = nil

--- a/test/fixtures/pet.rb
+++ b/test/fixtures/pet.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Pet < ActiveResource::Base
+  self.site = "http://37s.sunrise.i:3000"
+  self.prefix = "/people/:person_id/"
+end


### PR DESCRIPTION
When the prefix option is set for a Resource class, the `find_every` method, when used with the `from` option, does not instantiate the records with the given prefix_ options. #347 