### PR TITLE
Add REXML development dependency

### DIFF
--- a/activeresource.gemspec
+++ b/activeresource.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("rake")
   s.add_development_dependency("mocha", ">= 0.13.0")
+  s.add_development_dependency("rexml")
 end


### PR DESCRIPTION
This fixes test suite errors [[1]] such as:

~~~
... snip ...

  1) Error:
BaseTest#test_to_xml:
LoadError: cannot load such file -- rexml/document

... snip ...
~~~

Other possibility could be to add REXML as a runtime dependency, but that it probably not the right solution, because otherwise the dependency would have to be introduced in ActiveSupport [[2]].

[1]: https://travis-ci.org/github/rails/activeresource/jobs/748631192
[2]: https://github.com/rails/rails/commit/f624ed09abba4a0bae64eb699c9fc2e3f9bdc2dc