### PR TITLE
Fixed ActiveResource::ConnectionError#to_s to return a message which …

### DIFF
--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -10,6 +10,8 @@ module ActiveResource
     end
 
     def to_s
+      return @message if @message
+
       message = "Failed.".dup
       message << "  Response code = #{response.code}." if response.respond_to?(:code)
       message << "  Response message = #{response.message}." if response.respond_to?(:message)


### PR DESCRIPTION
I think this is a better behavior for ActiveResource::ConnectionError#message.
This fix enables to return a message which is given in the argument when it is initialized.

```
irb(main):004:0> e = ActiveResource::ConnectionError.new(response, "Custom error message with response code => #{response.code}")
=> #<ActiveResource::ConnectionError: Custom error message with response code => 999>
irb(main):005:0> e.message
=> "Custom error message with response code => 999"
irb(main):006:0> c = ActiveResource::Connection.new('')
=> #<ActiveResource::Connection:0x000055ff3f0aa340 @bearer_token=nil, @password=nil, @user=nil, @proxy=nil, @site=#<URI::...
irb(main):007:0> c.send(:handle_response, response)
Traceback (most recent call last):
        6: from /usr/local/bin/irb:23:in `<main>'
        5: from /usr/local/bin/irb:23:in `load'
        4: from /usr/local/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
        3: from (irb):7:in `<main>'
        2: from (irb):8:in `rescue in <main>'
        1: from /usr/local/bundle/gems/activeresource-5.1.1/lib/active_resource/connection.rb:161:in `handle_response'
ActiveResource::ConnectionError (Unknown response code: 999)
```