### PR TITLE
refs #355 rails renamed master to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 cache: bundler
 
 rvm:
+  - 2.7.2
   - 2.6.5
   - 2.5.7
   - ruby-head
@@ -48,6 +49,10 @@ matrix:
       env: BRANCH=5-2-stable
     - rvm: 2.6.5
       env: BRANCH=6-0-stable
+    - rvm: 2.7.2
+      env: BRANCH=6-0-stable
+    - rvm: 2.7.2
+      env: BRANCH=6-1-stable
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
-branch = ENV.fetch("BRANCH", "master")
+branch = ENV.fetch("BRANCH", "main")
 gem "activesupport", github: "rails/rails", branch: branch
 gem "activemodel", github: "rails/rails", branch: branch
 gem "activejob", github: "rails/rails", branch: branch


### PR DESCRIPTION
related with https://github.com/rails/activeresource/issues/355
By default there is no `master` branch  in Rails repositories