### PR TITLE
fix: Changing headers on base class doesn't change them in subclasses

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -39,6 +39,7 @@ module ActiveResource
   autoload :HttpMock
   autoload :Schema
   autoload :Singleton
+  autoload :InheritingHash
   autoload :Validations
   autoload :Collection
 end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -697,12 +697,11 @@ module ActiveResource
       end
 
       def headers
-        headers_state = self._headers || {}
-        if superclass != Object
-          self._headers = superclass.headers.merge(headers_state)
-        else
-          headers_state
-        end
+        self._headers ||= if superclass != Object
+                            InheritingHash.new(superclass.headers)
+                          else
+                            {}
+                          end
       end
 
       attr_writer :element_name

--- a/lib/active_resource/inheriting_hash.rb
+++ b/lib/active_resource/inheriting_hash.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  class InheritingHash < Hash
+    def initialize(parent_hash = {})
+      # Default hash value must be nil, which allows fallback lookup on parent hash
+      super(nil)
+      @parent_hash = parent_hash
+    end
+
+    def [](key)
+      super || @parent_hash[key]
+    end
+  end
+end

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -706,6 +706,32 @@ class BaseTest < ActiveSupport::TestCase
     assert_nil fruit.headers["key2"]
   end
 
+  def test_header_inheritance_can_override_upstream
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = "http://market"
+
+    fruit.headers["key"] = "fruit-value"
+    assert_equal "fruit-value", apple.headers["key"]
+
+    apple.headers["key"] = "apple-value"
+    assert_equal "apple-value", apple.headers["key"]
+    assert_equal "fruit-value", fruit.headers["key"]
+  end
+
+
+  def test_header_inheritance_should_not_override_upstream_on_read
+    fruit = Class.new(ActiveResource::Base)
+    apple = Class.new(fruit)
+    fruit.site = "http://market"
+
+    fruit.headers["key"] = "value"
+    assert_equal "value", apple.headers["key"]
+
+    fruit.headers["key"] = "new-value"
+    assert_equal "new-value", apple.headers["key"]
+  end
+
   def test_header_should_be_copied_to_main_thread_if_not_defined
     fruit = Class.new(ActiveResource::Base)
 


### PR DESCRIPTION
This can lead to a serious security issue if used as advised in the README 


> You can also set any specific HTTP header using the same way. As mentioned above, headers are thread-safe, so you can set headers dynamically, even in a multi-threaded environment:
> ```
> ActiveResource::Base.headers['Authorization'] = current_session_api_token
> ```
> 

If we consider this simple model:
```ruby
ApiModel < ActiveResource::Base
  self.site = "http://api.some-site.com"
end
```

And the following sequence:

```ruby
ActiveResource::Base.headers['Authorization'] = "Bob's TOKEN"
# Request made in Bob's name
ApiModel.find(1) 

ActiveResource::Base.headers['Authorization'] = "Alice's TOKEN"
# The request is still made with Bob's credentials, as ApiMode did read the header and kept a stale copy of it!!!
ApiModel.find(1) 
```

The fix should be compatible with the thread-safe attribute, although the code may need a second look.