### PR TITLE
Fix format lookup when JSON or XML are defined as acronyms

### DIFF
--- a/lib/active_resource/formats.rb
+++ b/lib/active_resource/formats.rb
@@ -5,12 +5,19 @@ module ActiveResource
     autoload :XmlFormat, "active_resource/formats/xml_format"
     autoload :JsonFormat, "active_resource/formats/json_format"
 
+    BUILT_IN = HashWithIndifferentAccess.new(
+      xml: ActiveResource::Formats::XmlFormat,
+      json: ActiveResource::Formats::JsonFormat,
+    ).freeze
+
     # Lookup the format class from a mime type reference symbol. Example:
     #
     #   ActiveResource::Formats[:xml]  # => ActiveResource::Formats::XmlFormat
     #   ActiveResource::Formats[:json] # => ActiveResource::Formats::JsonFormat
     def self.[](mime_type_reference)
-      ActiveResource::Formats.const_get(ActiveSupport::Inflector.camelize(mime_type_reference.to_s) + "Format")
+      BUILT_IN.fetch(mime_type_reference) do
+        ActiveResource::Formats.const_get(ActiveSupport::Inflector.camelize(mime_type_reference.to_s) + "Format")
+      end
     end
 
     def self.remove_root(data)

--- a/test/lib/formats_test.rb
+++ b/test/lib/formats_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class FormatsTest < ActiveSupport::TestCase
+  def test_resolving_json_and_xml_formats_when_defined_as_acronyms
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.acronym "JSON"
+      inflect.acronym "XML"
+    end
+
+    assert_equal ActiveResource::Formats::JsonFormat, ActiveResource::Formats[:json]
+    assert_equal ActiveResource::Formats::XmlFormat, ActiveResource::Formats[:xml]
+  ensure
+    ActiveSupport::Inflector.inflections do |inflect|
+      # N.B. It's not yet possible to use the public ActiveSupport::Inflector::Inflections#clear
+      # API because it doesn't reset @acronyms to be a Hash (the default value),
+      # instead it sets an empty array.
+      inflect.instance_variable_set(:@acronyms, {})
+    end
+  end
+
+  def test_resolving_custom_formats_uses_const_get
+    klass = Class.new
+    ActiveResource::Formats.const_set(:MsgpackFormat, klass)
+
+    assert_equal klass, ActiveResource::Formats[:msgpack]
+  ensure
+    ActiveResource::Formats.send(:remove_const, :MsgpackFormat)
+  end
+end


### PR DESCRIPTION
When JSON or XML are defined as acronyms the format lookup fails:

```ruby
ActiveSupport::Inflector.inflections do |inflect|
  inflect.acronym "XML"
  inflect.acronym "JSON"
end

ActiveResource::Formats[:xml]
# => NameError (uninitialized constant ActiveResource::Formats::XMLFormat)
# Did you mean?  ActiveResource::Formats::XmlFormat

ActiveResource::Formats[:json]
# => NameError (uninitialized constant ActiveResource::Formats::JSONFormat)
# Did you mean?  ActiveResource::Formats::JsonFormat
```

The proposed solution uses a hash to lookup built-in formats. For custom formats the implementation falls back to `const_get` after camelizing the MIME type reference. I didn't find many [public examples of custom formats](https://github.com/search?q=ActiveResource%3A%3AFormats%3A%3A&type=code), so not sure these are widely used.

Here's an example of this issue in the wild, from the `shopify_api` gem:
https://github.com/Shopify/shopify_api/issues/683