### PR TITLE
Fix belongs_to :post association

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -122,7 +122,11 @@ module ActiveResource::Associations
     method_name = reflection.name
     ivar_name = :"@#{method_name}"
 
-    defined_methods = self.methods - ActiveResource::CustomMethods.instance_methods(false)
+    defined_methods = self.methods
+    if self.ancestors.include?(ActiveResource::CustomMethods)
+      defined_methods = defined_methods - ActiveResource::CustomMethods.instance_methods(false)
+    end
+
     if defined_methods.include?(method_name)
       instance_variable_set(ivar_name, nil)
       remove_method(method_name)

--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -122,7 +122,8 @@ module ActiveResource::Associations
     method_name = reflection.name
     ivar_name = :"@#{method_name}"
 
-    if method_defined?(method_name)
+    defined_methods = self.methods - ActiveResource::CustomMethods.instance_methods(false)
+    if defined_methods.include?(method_name)
       instance_variable_set(ivar_name, nil)
       remove_method(method_name)
     end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1721,7 +1721,7 @@ module ActiveResource
     extend ActiveModel::Naming
     extend ActiveResource::Associations
 
-    include Callbacks, CustomMethods, Validations
+    include Callbacks, Validations
     include ActiveModel::Conversion
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml

--- a/test/cases/association_test.rb
+++ b/test/cases/association_test.rb
@@ -5,6 +5,7 @@ require "abstract_unit"
 require "fixtures/person"
 require "fixtures/beast"
 require "fixtures/customer"
+require "fixtures/blog"
 
 
 class AssociationTest < ActiveSupport::TestCase
@@ -12,7 +13,6 @@ class AssociationTest < ActiveSupport::TestCase
     @klass = ActiveResource::Associations::Builder::Association
     @reflection = ActiveResource::Reflection::AssociationReflection.new :belongs_to, :customer, {}
   end
-
 
   def test_validations_for_instance
     object = @klass.new(Person, :customers, {})
@@ -55,6 +55,23 @@ class AssociationTest < ActiveSupport::TestCase
   def test_belongs_to
     External::Person.belongs_to(:Customer)
     assert_equal 1, External::Person.reflections.select { |name, reflection| reflection.macro.eql?(:belongs_to) }.count
+  end
+
+  def test_belongs_to_post
+    response_body = { title: "some title" }.to_json
+    response_code = 201
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.post "/comments", {}, response_body, response_code
+    end
+
+    comment = ::Blog::Comment.new
+    comment.title = "other title"
+
+    assert_equal true, comment.save
+
+    response = ActiveResource::HttpMock.responses.flatten.last
+    assert_equal response.body, response_body
+    assert_equal response.code, response_code
   end
 
   def test_defines_belongs_to_finder_method_with_instance_variable_cache

--- a/test/fixtures/blog.rb
+++ b/test/fixtures/blog.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Blog
+  class ApplicationResource < ActiveResource::Base
+    self.site = "https://jsonplaceholder.typicode.com/"
+    self.include_format_in_path = false
+  end
+
+  class Post < ApplicationResource
+    has_many :comments
+  end
+
+  class Comment < ApplicationResource
+    belongs_to :post
+  end
+end

--- a/test/fixtures/blog.rb
+++ b/test/fixtures/blog.rb
@@ -13,4 +13,11 @@ module Blog
   class Comment < ApplicationResource
     belongs_to :post
   end
+
+  class CommentWithCustomMethodsIncluded < ApplicationResource
+    self.element_name = "comment"
+    self.collection_name = "comments"
+
+    include ActiveResource::CustomMethods
+  end
 end

--- a/test/fixtures/person.rb
+++ b/test/fixtures/person.rb
@@ -2,6 +2,8 @@
 
 class Person < ActiveResource::Base
   self.site = "http://37s.sunrise.i:3000"
+
+  include ActiveResource::CustomMethods
 end
 
 module External

--- a/test/fixtures/pet.rb
+++ b/test/fixtures/pet.rb
@@ -3,4 +3,6 @@
 class Pet < ActiveResource::Base
   self.site = "http://37s.sunrise.i:3000"
   self.prefix = "/people/:person_id/"
+
+  include ActiveResource::CustomMethods
 end

--- a/test/fixtures/street_address.rb
+++ b/test/fixtures/street_address.rb
@@ -3,4 +3,6 @@
 class StreetAddress < ActiveResource::Base
   self.site = "http://37s.sunrise.i:3000/people/:person_id"
   self.element_name = "address"
+
+  include ActiveResource::CustomMethods
 end


### PR DESCRIPTION
Hello! I faced the problem in following case:

```ruby
require 'activeresource'

class ApplicationResource < ActiveResource::Base
  self.site = 'https://jsonplaceholder.typicode.com/'
  self.include_format_in_path = false
end

class Post < ApplicationResource
  has_many :comments
end

class Comment < ApplicationResource
  belongs_to :post, foreign_key: 'postId'
end
```

Running such code will cause the problem:
```bash
Traceback (most recent call last):
	6: from index.rb:14:in `<main>'
	5: from index.rb:15:in `<class:Comment>'
	4: from /Users/username.rvm/gems/ruby-2.7.3/gems/activeresource-5.1.1/lib/active_resource/associations.rb:117:in `belongs_to'
	3: from /Users/username/.rvm/gems/ruby-2.7.3/gems/activeresource-5.1.1/lib/active_resource/associations/builder/association.rb:15:in `build'
	2: from /Users/username/.rvm/gems/ruby-2.7.3/gems/activeresource-5.1.1/lib/active_resource/associations/builder/belongs_to.rb:12:in `build'
	1: from /Users/username/.rvm/gems/ruby-2.7.3/gems/activeresource-5.1.1/lib/active_resource/associations.rb:127:in `defines_belongs_to_finder_method'
/Users/username/.rvm/gems/ruby-2.7.3/gems/activeresource-5.1.1/lib/active_resource/associations.rb:127:in `remove_method': method `post' not defined in Comment (NameError)
```

The problem was in ActiveResource::CustomMethods, which defines method `post`, which is method for HTTP post.
`method_defined?` in ActiveResource::Associations catches that method too, but `method_defined?` called on Comment class, which does not define method `post`.

Hope my change fits well.

UPD: following does the trick too, but looks strange and could cause a bug, if `Comment#post` should be present due to requirements.
```ruby
class Comment < ApplicationResource
  def post; end
  belongs_to :post, foreign_key: 'postId'
end
```