### PR TITLE
Stop requiring the useless and deprecated core_ext/uri

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -13,7 +13,6 @@ require "active_support/core_ext/object/duplicable"
 require "set"
 require "uri"
 
-require "active_support/core_ext/uri"
 require "active_resource/connection"
 require "active_resource/formats"
 require "active_resource/schema"

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/benchmark"
-require "active_support/core_ext/uri"
 require "active_support/core_ext/object/inclusion"
 require "net/https"
 require "date"


### PR DESCRIPTION
Ref: https://github.com/rails/rails/commit/93c35945cfd3594cafb08d941103cbd2723ee962

https://github.com/rails/activeresource/commit/91675dafc0404d7bb05978ed260cfb024a6e553c should have removed these requires...