### PR TITLE
Update ActiveModel & ActiveSupport dependencies

### DIFF
--- a/activeresource.gemspec
+++ b/activeresource.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency("activesupport", ">= 5.0", "< 7")
-  s.add_dependency("activemodel", ">= 5.0", "< 7")
+  s.add_dependency("activesupport", ">= 6.1", "< 8")
+  s.add_dependency("activemodel", ">= 6.1", "< 8")
   s.add_dependency("activemodel-serializers-xml", "~> 1.0")
 
   s.add_development_dependency("rake")

--- a/test/cases/base_errors_test.rb
+++ b/test/cases/base_errors_test.rb
@@ -63,8 +63,7 @@ class BaseErrorsTest < ActiveSupport::TestCase
   def test_should_iterate_over_errors
     [ :json, :xml ].each do |format|
       invalid_user_using_format(format) do
-        errors = []
-        @person.errors.each { |attribute, message| errors << [attribute, message] }
+        errors = @person.errors.map { |error| [error.attribute, error.message] }
         assert errors.include?([:name, "can't be blank"])
       end
     end


### PR DESCRIPTION
to support latest stable Rails 7 release

Breaking change in ActiveModel#errors fixed:
https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md#rails-610-december-09-2020