### PR TITLE
Always return a boolean value for `ActiveResource::Base#exists?`

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1078,7 +1078,6 @@ module ActiveResource
           response = connection.head(path, headers)
           (200..206).include? response.code.to_i
         end
-        # id && !find_single(id, options).nil?
       rescue ActiveResource::ResourceNotFound, ActiveResource::ResourceGone
         false
       end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1072,12 +1072,13 @@ module ActiveResource
       #
       #   Note.exists(1349) # => false
       def exists?(id, options = {})
-        if id
-          prefix_options, query_options = split_options(options[:params])
-          path = element_path(id, prefix_options, query_options)
-          response = connection.head(path, headers)
-          (200..206).include? response.code.to_i
-        end
+        return false unless id
+
+        prefix_options, query_options = split_options(options[:params])
+        path = element_path(id, prefix_options, query_options)
+        response = connection.head(path, headers)
+
+        (200..206).include?(response.code.to_i)
       rescue ActiveResource::ResourceNotFound, ActiveResource::ResourceGone
         false
       end

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1288,24 +1288,24 @@ class BaseTest < ActiveSupport::TestCase
   ########################################################################
   def test_exists
     # Class method.
-    assert_not Person.exists?(nil)
-    assert Person.exists?(1)
-    assert_not Person.exists?(99)
+    assert_equal false, Person.exists?(nil)
+    assert_equal true, Person.exists?(1)
+    assert_equal false, Person.exists?(99)
 
     # Instance method.
-    assert_not Person.new.exists?
-    assert Person.find(1).exists?
-    assert_not Person.new(id: 99).exists?
+    assert_equal false, Person.new.exists?
+    assert_equal true, Person.find(1).exists?
+    assert_equal false, Person.new(id: 99).exists?
 
     # Nested class method.
-    assert StreetAddress.exists?(1,  params: { person_id: 1 })
-    assert_not StreetAddress.exists?(1, params: { person_id: 2 })
-    assert_not StreetAddress.exists?(2, params: { person_id: 1 })
+    assert_equal true, StreetAddress.exists?(1,  params: { person_id: 1 })
+    assert_equal false, StreetAddress.exists?(1, params: { person_id: 2 })
+    assert_equal false, StreetAddress.exists?(2, params: { person_id: 1 })
 
     # Nested instance method.
-    assert StreetAddress.find(1, params: { person_id: 1 }).exists?
-    assert_not StreetAddress.new(id: 1, person_id: 2).exists?
-    assert_not StreetAddress.new(id: 2, person_id: 1).exists?
+    assert_equal true, StreetAddress.find(1, params: { person_id: 1 }).exists?
+    assert_equal false, StreetAddress.new(id: 1, person_id: 2).exists?
+    assert_equal false, StreetAddress.new(id: 2, person_id: 1).exists?
   end
 
   def test_exists_with_redefined_to_param


### PR DESCRIPTION
While going through the source code, I noticed that `ActiveResource::Base#exists?` included a line of code that was commented out. 

I also noticed that `ActiveResource::Base#exists?` could return three values: `nil`, `false`, and `true`. In `ActiveRecord`, the `#exists?` method always returns a boolean value. With this change, the `ActiveResource::Base#exists?` now always returns a boolean value.