### PR TITLE
Fix subclasses not inheriting headers set in the superclass

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -211,7 +211,7 @@ module ActiveResource
 
       # Builds headers for request to remote service.
       def build_request_headers(headers, http_method, uri)
-        authorization_header(http_method, uri).update(default_header).update(http_format_header(http_method)).update(headers)
+        authorization_header(http_method, uri).update(default_header).update(http_format_header(http_method)).update(headers.to_hash)
       end
 
       def response_auth_header

--- a/lib/active_resource/inheriting_hash.rb
+++ b/lib/active_resource/inheriting_hash.rb
@@ -11,5 +11,24 @@ module ActiveResource
     def [](key)
       super || @parent_hash[key]
     end
+
+    # Merges the flattened parent hash (if it's an InheritingHash)
+    # with ourself
+    def to_hash
+       @parent_hash.to_hash.merge(self)
+    end
+    
+    # So we can see the merged object in IRB or the Rails console
+    def pretty_print(pp)
+      pp.pp_hash to_hash
+    end  
+
+    def inspect
+      to_hash.inspect
+    end
+
+    def to_s
+      inspect
+    end
   end
 end


### PR DESCRIPTION
This fixes https://github.com/rails/activeresource/issues/376 - the headers weren't being shared because the InheritedHash class only works for individual key lookups. 

But when the headers InheritedHash was merged into the request headers inside the Connection class it didn't consider
the @parent_hash.