### PR TITLE
Adding type casting based on schema definition

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1699,11 +1699,9 @@ module ActiveResource
       end
 
       def type_cast_value(attribute_name, value)
-        if the_type = self.class.schema&.fetch(attribute_name.to_s, nil)
-          castable_type = ActiveModel::Type.lookup(the_type.to_sym) rescue nil
-          if castable_type
-            return castable_type.cast(value)
-          end
+        if schema_type = self.class.schema&.fetch(attribute_name, nil)
+          castable_type = ActiveModel::Type.lookup(schema_type.to_sym) rescue nil
+          return castable_type.cast(value) if castable_type
         end
         value
       end

--- a/test/cases/authorization_test.rb
+++ b/test/cases/authorization_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "base64"
 
 class AuthorizationTest < ActiveSupport::TestCase
   Response = Struct.new(:code)

--- a/test/cases/base/schema_test.rb
+++ b/test/cases/base/schema_test.rb
@@ -425,4 +425,35 @@ class SchemaTest < ActiveSupport::TestCase
     Person.schema = new_schema
     assert_equal Person.new(age: 20, name: "Matz").known_attributes, ["age", "name"]
   end
+
+  test "casting types" do
+    new_schema = {
+      "integer_field" => "integer",
+      "string_field" => "string",
+      "decimal_field" => "decimal",
+      "date_field" => "date",
+      "boolean_field" => "boolean"
+    }
+    Person.schema = new_schema
+
+    person = Person.new(
+      integer_field: "2.3",
+      string_field: "Rails FTW",
+      decimal_field: "12.3",
+      date_field: "2016-01-01",
+      boolean_field: "0"
+    )
+
+    assert_equal 2, person.integer_field
+    assert_equal "Rails FTW", person.string_field
+    assert_equal BigDecimal("12.3"), person.decimal_field
+    assert_equal Date.new(2016, 1, 1), person.date_field
+    assert_equal false, person.boolean_field
+
+    person.integer_field = 10
+    person.boolean_field = "1"
+
+    assert_equal 10, person.integer_field
+    assert_equal true, person.boolean_field
+  end
 end

--- a/test/fixtures/weather.rb
+++ b/test/fixtures/weather.rb
@@ -6,7 +6,7 @@ class Weather < ActiveResource::Base
 
   schema do
     string  :status
-    string  :temperature
+    integer :temperature
   end
 end
 


### PR DESCRIPTION
I'm learning to use Github's pull requests, so I could contribute to my favourite gems. Please do not judge harshly if I'm doing something wrong - it is not because of ignorance, but inexperience.

This pull request adds naive but workable solution for casting types base on schema definition.

For example:
```
Person.schema = { age: :integer, married: :boolean }
person = Person.new(age: "43.2", married: "1")
assert_equal 43, person.age
assert_equal true, person.married
```