### PR TITLE
[Active Record] Add belongs_to_resource to active record

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ branch = ENV.fetch("BRANCH", "main")
 gem "activesupport", github: "rails/rails", branch: branch
 gem "activemodel", github: "rails/rails", branch: branch
 gem "activejob", github: "rails/rails", branch: branch
+gem "activerecord", github: "rails/rails", branch: branch
+gem "sqlite3"
 
 gem "rubocop"
 gem "rubocop-minitest"

--- a/lib/active_resource/associations/active_record.rb
+++ b/lib/active_resource/associations/active_record.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  module Associations
+    module ActiveRecord
+      def belongs_to_resource(name, class_name: nil)
+        klass = class_name&.constantize || name.to_s.classify.constantize
+        define_method(name) { klass.find(send("#{name}_id")) }
+      end
+    end
+  end
+end

--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -21,5 +21,11 @@ module ActiveResource
         app.config.active_job.custom_serializers << ActiveResource::ActiveJobSerializer
       end
     end
+
+    initializer "active_resource.patch_active_record" do |app|
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::Base.extend(ActiveResource::Associations::ActiveRecord)
+      end
+    end
   end
 end

--- a/test/cases/active_record_association_test.rb
+++ b/test/cases/active_record_association_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "active_record"
+require "active_resource/associations/active_record"
+
+class ActiveRecordAssociationTest < ActiveSupport::TestCase
+  setup do
+    setup_response # find me in abstract_unit
+
+    ActiveRecord::Base.establish_connection(
+      adapter: "sqlite3",
+      database: ":memory:"
+    )
+    ActiveRecord::Schema.define do
+      self.verbose = false
+
+      create_table :test_records, force: true do |t|
+        t.string :name
+        t.belongs_to :person
+        t.belongs_to :book
+        t.timestamps
+      end
+    end
+
+    ActiveRecord::Base.extend(ActiveResource::Associations::ActiveRecord)
+
+    class TestRecord < ActiveRecord::Base
+      belongs_to_resource :person
+      belongs_to_resource :book, class_name: "Product"
+    end
+  end
+
+  def test_belongs_to_resource
+    record = TestRecord.create(name: "test", person_id: 1)
+    assert_equal record.person.name, "Matz"
+  end
+
+  def test_belongs_to_resource_with_class_name
+    record = TestRecord.create(name: "test", person_id: 1, book_id: 1)
+    assert_equal record.book.name, "Rails book"
+  end
+end


### PR DESCRIPTION
## Pull Request Description

This pull request adds the `belongs_to_resource` class method to the ActiveResource Ruby on Rails gem. This method allows for the association of an ActiveResource with an ActiveRecord. 

### Changes Made

The `belongs_to_resource` method has been added to the ActiveResource::Base
class. This method takes two arguments: the name of the association and
class_name keyword argument. The options hash can include the `class_name`
option to specify the name of the ActiveResource class to associate with.

### Example Usage

```ruby
class Person < ActiveResource::Base
  self.site = "http://api.people.com:3000"
end

class Address < ActiveRecord::Base
  belongs_to_resource :person
end
```

With this association, an `Address` active record model can be associated with a `Person` active resource via the `person_id` foreign key. The `Person` object can be accessed through the `person` method on the `Address` object.

### Testing

Unit tests have been added to ensure that the `belongs_to_resource` method works as expected. These tests cover the basic functionality of the method, as well as the use of the `class_name`.

### Related Issue

This pull request is related to https://github.com/rails/activeresource/issues/292.
