### PR TITLE
[Enhancement] Allows HttpMock to ignore query params from url path if given the option

### DIFF
--- a/lib/active_resource/http_mock.rb
+++ b/lib/active_resource/http_mock.rb
@@ -62,7 +62,7 @@ module ActiveResource
         #   @responses[Request.new(:post, path, nil, request_headers, options)] = Response.new(body || "", status, response_headers)
         # end
         module_eval <<-EOE, __FILE__, __LINE__ + 1
-          def #{method}(path, request_headers = {}, body = nil, status = 200, response_headers = {}, options: {})
+          def #{method}(path, request_headers = {}, body = nil, status = 200, response_headers = {}, options = {})
             request  = Request.new(:#{method}, path, nil, request_headers, options)
             response = Response.new(body || "", status, response_headers)
 

--- a/lib/active_resource/http_mock.rb
+++ b/lib/active_resource/http_mock.rb
@@ -285,7 +285,7 @@ module ActiveResource
 
     def ==(req)
       if @options && @options[:omit_query_in_path]
-        clean_path == req.clean_path && method == req.method && headers_match?(req)
+        remove_query_params_from_path == req.remove_query_params_from_path && method == req.method && headers_match?(req)
       else
         path == req.path && method == req.method && headers_match?(req)
       end
@@ -295,8 +295,11 @@ module ActiveResource
       "<#{method.to_s.upcase}: #{path} [#{headers}] (#{body})>"
     end
 
-    def clean_path
-      path.split("?").first # Removes query parameters from the path
+    # Removes query parameters from the path.
+    #
+    # @return [String] the path without query parameters
+    def remove_query_params_from_path
+      path.split("?").first
     end
 
     private

--- a/test/cases/http_mock_test.rb
+++ b/test/cases/http_mock_test.rb
@@ -193,6 +193,16 @@ class HttpMockTest < ActiveSupport::TestCase
     assert_equal 2, ActiveResource::HttpMock.responses.length
   end
 
+  test "omits query parameters from the URL when options[:omit_query_params] is true" do
+    ActiveResource::HttpMock.respond_to do |mock|
+      mock.get("/endpoint", {}, "Response", options: { omit_query_in_path: true })
+    end
+
+    response = request(:get, "/endpoint?param1=value1&param2=value2")
+
+    assert_equal "Response", response.body
+  end
+
   def request(method, path, headers = {}, body = nil)
     if method.in?([:patch, :put, :post])
       @http.send(method, path, body, headers)

--- a/test/cases/http_mock_test.rb
+++ b/test/cases/http_mock_test.rb
@@ -195,7 +195,7 @@ class HttpMockTest < ActiveSupport::TestCase
 
   test "omits query parameters from the URL when options[:omit_query_params] is true" do
     ActiveResource::HttpMock.respond_to do |mock|
-      mock.get("/endpoint", {}, "Response", options: { omit_query_in_path: true })
+      mock.get("/endpoint", {}, "Response", 200, {}, { omit_query_in_path: true })
     end
 
     response = request(:get, "/endpoint?param1=value1&param2=value2")


### PR DESCRIPTION
Recently, I encountered an issue where date-time values within query parameters were not accurately detected and parsed, leading to inaccuracies in the mocks I had. I had to either change the business logic to not use date-time values in query parameters, or to change the way the date-time values were parsed. For me, the former was not an option, so I had to change the way the date-time values were parsed.

Currently ActiveResource::HttpMock does not provide a way to omit the query parameters from the URL when matching a request, while I understand that this is probably not a common use case since it will lead to a lot of issues when the mocked URL is not specific enough, I still think it would be useful to have the option to omit the query parameters from the URL when matching a request.

In this PR I have added a `options` parameter, which defaults to `{}`. When the `options[:omit_query_params]` is set to `true`, the query parameters will be omitted from the URL when matching a request. This does not change the default behavior of the `ActiveResource::HttpMock` class, rather it adds an option to change the behavior. In addition, I have also added a method `remove_query_params_from_path` to remove the query parameters.

I hope this is not too much of a niche use case, and that this PR can be merged. If not, I would love to hear your feedback on this.