### PR TITLE
Raise ActiveResource::ConnectionRefusedError on Errno::ECONNREFUSED

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -127,6 +127,8 @@ module ActiveResource
         raise TimeoutError.new(e.message)
       rescue OpenSSL::SSL::SSLError => e
         raise SSLError.new(e.message)
+      rescue Errno::ECONNREFUSED => e
+        raise ConnectionRefusedError.new(e.message)
       end
 
       # Handles response and error codes from the remote service.

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -35,6 +35,14 @@ module ActiveResource
     def to_s; @message ; end
   end
 
+  # Raised when a Errno::ECONNREFUSED occurs.
+  class ConnectionRefusedError < ConnectionError
+    def initialize(message)
+      @message = message
+    end
+    def to_s; @message ; end
+  end
+
   # 3xx Redirection
   class Redirection < ConnectionError # :nodoc:
     def to_s

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -36,12 +36,7 @@ module ActiveResource
   end
 
   # Raised when a Errno::ECONNREFUSED occurs.
-  class ConnectionRefusedError < ConnectionError
-    def initialize(message)
-      @message = message
-    end
-    def to_s; @message ; end
-  end
+  class ConnectionRefusedError < Errno::ECONNREFUSED; end
 
   # 3xx Redirection
   class Redirection < ConnectionError # :nodoc:

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -289,6 +289,13 @@ class ConnectionTest < ActiveSupport::TestCase
     assert_raise(ActiveResource::ConnectionRefusedError) { @conn.get("/people/1.json") }
   end
 
+  def test_handle_econnrefused_with_backwards_compatible_error
+    http = Net::HTTP.new("")
+    @conn.expects(:http).returns(http)
+    http.expects(:get).raises(Errno::ECONNREFUSED, "Failed to open TCP connection")
+    assert_raise(Errno::ECONNREFUSED) { @conn.get("/people/1.json") }
+  end
+
   def test_auth_type_can_be_string
     @conn.auth_type = "digest"
     assert_equal(:digest, @conn.auth_type)

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -282,6 +282,13 @@ class ConnectionTest < ActiveSupport::TestCase
     assert_raise(ActiveResource::SSLError) { @conn.get("/people/1.json") }
   end
 
+  def test_handle_econnrefused
+    http = Net::HTTP.new("")
+    @conn.expects(:http).returns(http)
+    http.expects(:get).raises(Errno::ECONNREFUSED, "Failed to open TCP connection")
+    assert_raise(ActiveResource::ConnectionRefusedError) { @conn.get("/people/1.json") }
+  end
+
   def test_auth_type_can_be_string
     @conn.auth_type = "digest"
     assert_equal(:digest, @conn.auth_type)


### PR DESCRIPTION
## What

Raises a custom `ActiveResource::ConnectionError` when failing to connect to an external endpoint completely, changing something like:

```
Errno::ECONNREFUSED: Failed to open TCP connection to 127.0.0.1:4568 (Connection refused - connect(2) for "127.0.0.1" port 4568)
```

...into:

```
ActiveResource::ConnectionRefusedError: Failed to open TCP connection to 127.0.0.1:4568 (Connection refused - connect(2) for "127.0.0.1" port 4568)
```

## Why

Follows the convention of rescuing network errors and wrapping them in `ActiveResource` custom errors, allowing them to be rescued without leaking knowledge of internals.