### PR TITLE
Remove unused `new_connection` method from tests

### DIFF
--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -331,10 +331,6 @@ class ConnectionTest < ActiveSupport::TestCase
     end
   end
 
-  def new_connection
-    ActiveResource::Connection.new("http://localhost")
-  end
-
   protected
     def assert_response_raises(klass, code)
       assert_raise(klass, "Expected response code #{code} to raise #{klass}") do


### PR DESCRIPTION
This was added in https://github.com/rails/activeresource/pull/119 but appears to be unused?