### PR TITLE
HTTP status 402 PaymentRequired

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -213,6 +213,7 @@ module ActiveResource
   # * 301, 302, 303, 307 - ActiveResource::Redirection
   # * 400 - ActiveResource::BadRequest
   # * 401 - ActiveResource::UnauthorizedAccess
+  # * 402 - ActiveResource::PaymentRequired
   # * 403 - ActiveResource::ForbiddenAccess
   # * 404 - ActiveResource::ResourceNotFound
   # * 405 - ActiveResource::MethodNotAllowed

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -140,6 +140,8 @@ module ActiveResource
           raise(BadRequest.new(response))
         when 401
           raise(UnauthorizedAccess.new(response))
+        when 402
+          raise(PaymentRequired.new(response))
         when 403
           raise(ForbiddenAccess.new(response))
         when 404

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -57,6 +57,10 @@ module ActiveResource
   class UnauthorizedAccess < ClientError # :nodoc:
   end
 
+  # 402 Payment Required
+  class PaymentRequired < ClientError # :nodoc:
+  end
+
   # 403 Forbidden
   class ForbiddenAccess < ClientError # :nodoc:
   end

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -74,6 +74,9 @@ class ConnectionTest < ActiveSupport::TestCase
     # 401 is an unauthorized request
     assert_response_raises ActiveResource::UnauthorizedAccess, 401
 
+    # 402 is a payment required error.
+    assert_response_raises ActiveResource::PaymentRequired, 402
+
     # 403 is a forbidden request (and authorizing will not help)
     assert_response_raises ActiveResource::ForbiddenAccess, 403
 


### PR DESCRIPTION
ActiveResource exception for HTTP status 402 (`ActiveResource::PaymentRequired`).
It is already used by Shopify (https://shopify.dev/docs/api/usage/response-codes).