### PR TITLE
Replace deprecated `ProxyObject` with `BasicObject`

### DIFF
--- a/test/setter_trap.rb
+++ b/test/setter_trap.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SetterTrap < ActiveSupport::ProxyObject
+class SetterTrap < BasicObject
   class << self
     def rollback_sets(obj)
       trapped = new(obj)


### PR DESCRIPTION
It has been deprecated in https://github.com/rails/rails/pull/51638