### PR TITLE
Use a custom deprecator instead of ActiveSupport::Deprecation directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,17 @@ jobs:
               BRANCH: 7-1-stable
           - ruby: "3.1"
             env:
+              BRANCH: 7-2-stable
+            experimental: false
+          - ruby: "3.2"
+            env:
+              BRANCH: 7-2-stable
+            experimental: false
+          - ruby: "3.3"
+            env:
+              BRANCH: 7-2-stable
+          - ruby: "3.1"
+            env:
               BRANCH: main
             experimental: true
           - ruby: "3.2"

--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -46,6 +46,14 @@ module ActiveResource
   autoload :InheritingHash
   autoload :Validations
   autoload :Collection
+
+  def self.deprecator
+    @deprecator ||= if ActiveSupport::VERSION::STRING >= '7.2'
+      ActiveSupport::Deprecation.new(VERSION::STRING, 'ActiveResource')
+    else
+      ActiveSupport::Deprecation
+    end
+  end
 end
 
 require "active_resource/railtie" if defined?(Rails.application)

--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -48,8 +48,8 @@ module ActiveResource
   autoload :Collection
 
   def self.deprecator
-    @deprecator ||= if ActiveSupport::VERSION::STRING >= '7.2'
-      ActiveSupport::Deprecation.new(VERSION::STRING, 'ActiveResource')
+    @deprecator ||= if ActiveSupport::VERSION::STRING >= "7.2"
+      ActiveSupport::Deprecation.new(VERSION::STRING, "ActiveResource")
     else
       ActiveSupport::Deprecation
     end

--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -21,5 +21,9 @@ module ActiveResource
         app.config.active_job.custom_serializers << ActiveResource::ActiveJobSerializer
       end
     end
+
+    initializer "active_resource.deprecator" do |app|
+      app.deprecators[:active_resource] = ActiveResource.deprecator
+    end
   end
 end

--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -57,7 +57,7 @@ module ActiveResource
         errors = decoded["errors"] || {}
         if errors.kind_of?(Array)
           # 3.2.1-style with array of strings
-          ActiveSupport::Deprecation.warn("Returning errors as an array of strings is deprecated.")
+          ActiveResource.deprecator.warn("Returning errors as an array of strings is deprecated.")
           from_array errors, save_cache
         else
           # 3.2.2+ style
@@ -65,7 +65,7 @@ module ActiveResource
         end
       else
         # <3.2-style respond_with - lacks 'errors' key
-        ActiveSupport::Deprecation.warn('Returning errors as a hash without a root "errors" key is deprecated.')
+        ActiveResource.deprecator.warn('Returning errors as a hash without a root "errors" key is deprecated.')
         from_hash decoded, save_cache
       end
     end

--- a/test/cases/base_errors_test.rb
+++ b/test/cases/base_errors_test.rb
@@ -116,7 +116,7 @@ class BaseErrorsTest < ActiveSupport::TestCase
       mock.post "/people.json", {}, %q({"errors":["Age can't be blank", "Name can't be blank", "Name must start with a letter", "Person quota full for today.", "Phone work can't be blank", "Phone is not valid"]}), 422, "Content-Type" => "application/json; charset=utf-8"
     end
 
-    assert_deprecated(/as an array/) do
+    assert_deprecated(/as an array/, ActiveResource.deprecator) do
       invalid_user_using_format(:json) do
         assert @person.errors[:name].any?
         assert_equal ["can't be blank"], @person.errors[:age]
@@ -133,7 +133,7 @@ class BaseErrorsTest < ActiveSupport::TestCase
       mock.post "/people.json", {}, %q({"age":["can't be blank"],"name":["can't be blank", "must start with a letter"],"person":["quota full for today."],"phone_work":["can't be blank"],"phone":["is not valid"]}), 422, "Content-Type" => "application/json; charset=utf-8"
     end
 
-    assert_deprecated(/without a root/) do
+    assert_deprecated(/without a root/, ActiveResource.deprecator) do
       invalid_user_using_format(:json) do
         assert @person.errors[:name].any?
         assert_equal ["can't be blank"], @person.errors[:age]


### PR DESCRIPTION
This will address some errors we are getting while trying to update to rails 7.2