### PR TITLE
ActiveSupport::Deprecation singleton was deprecated in 7.1, not 7.2

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -47,7 +47,7 @@ module ActiveResource
   autoload :Validations
   autoload :Collection
 
-  if ActiveSupport::VERSION::STRING >= "7.2"
+  if ActiveSupport::VERSION::STRING >= "7.1"
     def self.deprecator
       @deprecator ||= ActiveSupport::Deprecation.new(VERSION::STRING, "ActiveResource")
     end


### PR DESCRIPTION
ActiveResource 6.1.2 included a custom deprecator which uses an instance of `ActiveSupport::Deprecation` rather than the singleton in Rails >= 7.2. That is because of [this deprecation](https://github.com/rails/rails/blob/d78c6e4e3e5f89e22f002389df29448f3238e019/activesupport/lib/active_support/deprecation/instance_delegator.rb#L37) in ActiveSupport.

The deprecation was actually shipped in Rails 7.1.0.beta1, so the condition should be on Rails >= 7.1.

<img width="482" alt="image" src="https://github.com/user-attachments/assets/edf15ce4-342e-480b-88a7-f4031dd2f71b">

The incorrect condition is causing CI for updates including ActiveResource >= 6.1.2 to fail with:

```
ActiveSupport::DeprecationException: DEPRECATION WARNING: Calling behavior= on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use Rails.application.deprecators.behavior= instead) (called from <main> at /app/config/environment.rb:8) (ActiveSupport::DeprecationException)
--
  | /app/config/environment.rb:8:in `<main>'
```

---

There are also two commits which fix CI.