### PR TITLE
[ISSUE-408] Lazy Network Calls on Collections

### DIFF
--- a/lib/active_resource/associations.rb
+++ b/lib/active_resource/associations.rb
@@ -150,7 +150,7 @@ module ActiveResource::Associations
       elsif !new_record?
         instance_variable_set(ivar_name, reflection.klass.find(:all, params: { "#{self.class.element_name}_id": self.id }))
       else
-        instance_variable_set(ivar_name, self.class.collection_parser.new)
+        instance_variable_set(ivar_name, reflection.klass.find(:all))
       end
     end
   end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1125,7 +1125,7 @@ module ActiveResource
 
           collection_parser.new([], options[:from]).tap do |parser|
             parser.resource_class = self
-            parser.original_params = query_options
+            parser.query_params = query_options
             parser.prefix_options = prefix_options
             parser.path_params = params
           end

--- a/lib/active_resource/collection.rb
+++ b/lib/active_resource/collection.rb
@@ -5,11 +5,9 @@ require "active_support/inflector"
 
 module ActiveResource # :nodoc:
   class Collection # :nodoc:
-    SELF_DEFINE_METHODS = [:to_a, :all?]
     include Enumerable
-    delegate :to_yaml, :all?, *(Array.instance_methods(false) - SELF_DEFINE_METHODS), to: :to_a
+    delegate :to_yaml, *Array.public_instance_methods(false), to: :fetch_resources!
 
-    # The array of actual elements returned by index actions
     attr_accessor :elements, :resource_class, :query_params, :path_params
     attr_writer :prefix_options
     attr_reader :from
@@ -65,56 +63,92 @@ module ActiveResource # :nodoc:
       parse_response(@elements) if @elements.present?
     end
 
+    # Processes and sets the collection elements. This method assigns the provided `elements`
+    # (or an empty array if none provided) to the `@elements` instance variable.
+    #
+    # ==== Arguments
+    #
+    # +elements+ (Array<Object>) - An optional array of resources to be set as the collection elements.
+    #                              Defaults to an empty array.
+    #
+    # This method is called after fetching the resource and can be overridden by subclasses to
+    # handle any specific response format of the API.
     def parse_response(elements)
       @elements = elements || []
     end
 
+    # Returns the prefix options for the collection, which are used for constructing the resource path.
+    #
+    # ==== Returns
+    #
+    # [Hash] The prefix options for the collection.
     def prefix_options
       @prefix_options || {}
     end
 
-    # Makes network request to get the elements and returns self
+    # Executes the request to fetch the collection of resources from the API and returns the collection.
+    #
+    # ==== Returns
+    #
+    # [ActiveResource::Collection] The collection of resources.
     def call
-      to_a
+      fetch_resources!
       self
     end
 
-    def to_a
-      response =
-        case from
-        when Symbol
-          resource_class.get(from, path_params)
-        when String
-          path = "#{from}#{query_string(query_params)}"
-          resource_class.format.decode(resource_class.connection.get(path, resource_class.headers).body)
-        else
-          path = resource_class.collection_path(prefix_options, query_params)
-          resource_class.format.decode(resource_class.connection.get(path, resource_class.headers).body)
-        end
-
-      # Update the elements
-      parse_response(response)
-      @elements = @elements.map do |element|
-        resource_class.instantiate_record(element, prefix_options)
-      end
-    rescue ActiveResource::ResourceNotFound
-      # Swallowing ResourceNotFound exceptions and return nothing - as per ActiveRecord.
-      # Needs to be empty array as Array methods are delegated
-      []
-    end
-
+    # Returns the first resource in the collection, or creates a new resource using the provided
+    # attributes if the collection is empty.
+    #
+    # ==== Arguments
+    #
+    # +attributes+ (Hash) - The attributes for creating the resource.
+    #
+    # ==== Returns
+    #
+    # [Object] The first resource, or a newly created resource if none exist.
+    #
+    # ==== Example
+    #   post = PostCollection.where(title: "New Post").first_or_create
+    #   # => Post instance with title "New Post"
     def first_or_create(attributes = {})
       first || resource_class.create(query_params.update(attributes))
     rescue NoMethodError
       raise "Cannot create resource from resource type: #{resource_class.inspect}"
     end
 
+    # Returns the first resource in the collection, or initializes a new resource using the provided
+    # attributes if the collection is empty.
+    #
+    # ==== Arguments
+    #
+    # +attributes+ (Hash) - The attributes for initializing the resource.
+    #
+    # ==== Returns
+    #
+    # [Object] The first resource, or a newly initialized resource if none exist.
+    #
+    # ==== Example
+    #   post = PostCollection.where(title: "New Post").first_or_initialize
+    #   # => Post instance with title "New Post"
     def first_or_initialize(attributes = {})
       first || resource_class.new(query_params.update(attributes))
     rescue NoMethodError
       raise "Cannot build resource from resource type: #{resource_class.inspect}"
     end
 
+    # Filters the collection based on the provided clauses (query parameters).
+    #
+    # ==== Arguments
+    #
+    # +clauses+ (Hash) - A hash of query parameters used to filter the collection.
+    #
+    # ==== Returns
+    #
+    # [ActiveResource::Collection] A new collection filtered by the specified clauses.
+    #
+    # ==== Example
+    #   filtered_posts = PostCollection.where(title: "Post 1")
+    #   # => PostCollection:xxx (filtered collection)
     def where(clauses = {})
       raise ArgumentError, "expected a clauses Hash, got #{clauses.inspect}" unless clauses.is_a? Hash
       new_clauses = query_params.merge(clauses)
@@ -124,6 +158,34 @@ module ActiveResource # :nodoc:
     private
       def query_string(options)
         "?#{options.to_query}" unless options.nil? || options.empty?
+      end
+
+      # Fetches resources from the API and parses the response. The resources are then mapped to their respective
+      # resource class instances.
+      #
+      # ==== Returns
+      #
+      # [Array<Object>] The collection of resources retrieved from the API.
+      def fetch_resources!
+        response =
+          case from
+          when Symbol
+            resource_class.get(from, path_params)
+          when String
+            path = "#{from}#{query_string(query_params)}"
+            resource_class.format.decode(resource_class.connection.get(path, resource_class.headers).body)
+          else
+            path = resource_class.collection_path(prefix_options, query_params)
+            resource_class.format.decode(resource_class.connection.get(path, resource_class.headers).body)
+          end
+
+        # Update the elements
+        parse_response(response)
+        @elements.map! { |e| resource_class.instantiate_record(e, prefix_options) }
+      rescue ActiveResource::ResourceNotFound
+        # Swallowing ResourceNotFound exceptions and return nothing - as per ActiveRecord.
+        # Needs to be empty array as Array methods are delegated
+        []
       end
   end
 end

--- a/lib/active_resource/collection.rb
+++ b/lib/active_resource/collection.rb
@@ -10,7 +10,7 @@ module ActiveResource # :nodoc:
     delegate :to_yaml, :all?, *(Array.instance_methods(false) - SELF_DEFINE_METHODS), to: :to_a
 
     # The array of actual elements returned by index actions
-    attr_accessor :elements, :resource_class, :original_params, :path_params
+    attr_accessor :elements, :resource_class, :query_params, :path_params
     attr_writer :prefix_options
     attr_reader :from
 
@@ -85,10 +85,10 @@ module ActiveResource # :nodoc:
         when Symbol
           resource_class.get(from, path_params)
         when String
-          path = "#{from}#{query_string(original_params)}"
+          path = "#{from}#{query_string(query_params)}"
           resource_class.format.decode(resource_class.connection.get(path, resource_class.headers).body)
         else
-          path = resource_class.collection_path(prefix_options, original_params)
+          path = resource_class.collection_path(prefix_options, query_params)
           resource_class.format.decode(resource_class.connection.get(path, resource_class.headers).body)
         end
 
@@ -104,20 +104,20 @@ module ActiveResource # :nodoc:
     end
 
     def first_or_create(attributes = {})
-      first || resource_class.create(original_params.update(attributes))
+      first || resource_class.create(query_params.update(attributes))
     rescue NoMethodError
       raise "Cannot create resource from resource type: #{resource_class.inspect}"
     end
 
     def first_or_initialize(attributes = {})
-      first || resource_class.new(original_params.update(attributes))
+      first || resource_class.new(query_params.update(attributes))
     rescue NoMethodError
       raise "Cannot build resource from resource type: #{resource_class.inspect}"
     end
 
     def where(clauses = {})
       raise ArgumentError, "expected a clauses Hash, got #{clauses.inspect}" unless clauses.is_a? Hash
-      new_clauses = original_params.merge(clauses)
+      new_clauses = query_params.merge(clauses)
       resource_class.where(new_clauses)
     end
 

--- a/test/cases/association_test.rb
+++ b/test/cases/association_test.rb
@@ -43,8 +43,8 @@ class AssociationTest < ActiveSupport::TestCase
 
   def test_has_many_on_new_record
     Post.send(:has_many, :topics)
-    Topic.stubs(:find).returns([:unexpected_response])
-    assert_equal [], Post.new.topics.to_a
+
+    assert_kind_of ActiveResource::Collection, Post.new.topics
   end
 
   def test_has_one

--- a/test/cases/collection_test.rb
+++ b/test/cases/collection_test.rb
@@ -76,8 +76,8 @@ class CollectionInheritanceTest < ActiveSupport::TestCase
     assert_equal PaginatedPost, PaginatedPost.where(page: 2).resource_class
   end
 
-  def test_setting_collection_parser_original_params
-    assert_equal({ page: 2 }, PaginatedPost.where(page: 2).original_params)
+  def test_setting_collection_parser_query_params
+    assert_equal({ page: 2 }, PaginatedPost.where(page: 2).query_params)
   end
 
   def test_custom_accessor

--- a/test/cases/collection_test.rb
+++ b/test/cases/collection_test.rb
@@ -9,14 +9,6 @@ class CollectionTest < ActiveSupport::TestCase
 end
 
 class BasicCollectionTest < CollectionTest
-  def test_collection_respond_to_collect!
-    assert @collection.respond_to?(:collect!)
-  end
-
-  def test_collection_respond_to_map!
-    assert @collection.respond_to?(:map!)
-  end
-
   def test_collection_respond_to_first_or_create
     assert @collection.respond_to?(:first_or_create)
   end
@@ -33,19 +25,6 @@ class BasicCollectionTest < CollectionTest
     assert_raise(RuntimeError) { @collection.first_or_initialize }
   end
 
-  def test_collect_bang_modifies_elements
-    elements = %w(a b c)
-    @collection.elements = elements
-    results = @collection.collect! { |i| i + "!" }
-    assert_equal results.to_a, elements.collect! { |i| i + "!" }
-  end
-
-  def test_collect_bang_returns_collection
-    @collection.elements = %w(a)
-    results = @collection.collect! { |i| i + "!" }
-    assert_kind_of ActiveResource::Collection, results
-  end
-
   def respond_to_where
     assert @collection.respond_to?(:where)
   end
@@ -53,7 +32,7 @@ end
 
 class PaginatedCollection < ActiveResource::Collection
   attr_accessor :next_page
-  def initialize(parsed = {})
+  def parse_response(parsed)
     @elements = parsed["results"]
     @next_page = parsed["next_page"]
   end
@@ -102,7 +81,7 @@ class CollectionInheritanceTest < ActiveSupport::TestCase
   end
 
   def test_custom_accessor
-    assert_equal PaginatedPost.find(:all).next_page, @posts_hash[:next_page]
+    assert_equal PaginatedPost.find(:all).call.next_page, @posts_hash[:next_page]
   end
 
   def test_first_or_create

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -258,7 +258,7 @@ class ConnectionTest < ActiveSupport::TestCase
     @http = mock("new Net::HTTP")
     @conn.expects(:http).returns(@http)
     path = "/people/1.xml"
-    @http.expects(:get).with(path, "Accept" => "application/xhtml+xml").returns(ActiveResource::Response.new(@matz, 200, "Content-Type" => "text/xhtml"))
+    @http.expects(:get).with(path, { "Accept" => "application/xhtml+xml" }).returns(ActiveResource::Response.new(@matz, 200, { "Content-Type" => "text/xhtml" }))
     assert_nothing_raised { @conn.get(path, "Accept" => "application/xhtml+xml") }
   end
 


### PR DESCRIPTION
## Summary
This is for https://github.com/rails/activeresource/issues/408 .

**It is a breaking change**

`ActiveResource` allows you to chain `where` methods such as

```ruby
result = MyActiveResourceModel.where(first_name: "John").where(last_name: "Doe")
```

This improves it so that network calls are only performed when resources are accessed.

**With this PR**

```ruby
# This makes 0 API call
result = MyActiveResourceModel.where(first_name: "John").where(last_name: "Doe")

# This makes 1 API call
result.to_a

# This makes 1 API call
result.any?
```