### PR TITLE
Set `ActiveResource::Base.logger` during boot

### DIFF
--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -28,6 +28,10 @@ module ActiveResource
       end
     end
 
+    initializer "active_resource.logger" do
+      ActiveSupport.on_load(:active_resource) { self.logger ||= ::Rails.logger }
+    end
+
     initializer "active_resource.http_mock" do
       ActiveSupport.on_load(:active_support_test_case) do
         teardown { ActiveResource::HttpMock.reset! }


### PR DESCRIPTION
When left un-configured during boot, default the value of `ActiveResource::Base.logger` to `Rails.logger`.

This change draws inspiration from the corresponding lines in the `active_record/railtie.rb` file's [active_record.logger][] initializer.

[active_record.logger]: https://github.com/rails/rails/blob/1b327ad4ed0fe5e8c2f1f795e2cf63f90a9833b5/activerecord/lib/active_record/railtie.rb#L97-L99