### PR TITLE
Reset `ActiveResource::HttpMock` in test teardown

### DIFF
--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -27,5 +27,11 @@ module ActiveResource
         app.deprecators[:active_resource] = ActiveResource.deprecator
       end
     end
+
+    initializer "active_resource.http_mock" do
+      ActiveSupport.on_load(:active_support_test_case) do
+        teardown { ActiveResource::HttpMock.reset! }
+      end
+    end
   end
 end


### PR DESCRIPTION
Calls to `ActiveResource::HttpMock.respond_to` without arguments reset the mock, clearing previously defined request-response pairs.

Invocations with a final positional argument of `false` **do not clear** previously defined request-response mocks. This behavior can be useful for tests that require a sequence of Http mock definitions.

Regardless of the style of invocation, the collection of mocks should be reset between individual tests, so that mock state does not leak into subsequent test cases, which has the potential to cause unpredictable behavior and flaky tests.

This change defines an `ActiveSupport.on_load` hook to execute for `ActiveSupport::TestCase` instances. The hook defines a [teardown][] block to invoke `ActiveResource::HttpMock#reset!` between test cases.

[teardown]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/Testing/SetupAndTeardown/ClassMethods.html#method-i-teardown