### PR TITLE
Add `before_reload`, `after_reload`, and `around_reload` callbacks

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1442,7 +1442,9 @@ module ActiveResource
     #   my_branch.reload
     #   my_branch.name # => "Wilson Road"
     def reload
-      self.load(self.class.find(to_param, params: @prefix_options).attributes, false, true)
+      run_callbacks :reload do
+        self.load(self.class.find(to_param, params: @prefix_options).attributes, false, true)
+      end
     end
 
     # A method to manually load attributes from a \hash. Recursively loads collections of

--- a/lib/active_resource/callbacks.rb
+++ b/lib/active_resource/callbacks.rb
@@ -8,6 +8,7 @@ module ActiveResource
 
     CALLBACKS = [
       :before_validation, :after_validation, :before_save, :around_save, :after_save,
+      :before_reload, :around_reload, :after_reload,
       :before_create, :around_create, :after_create, :before_update, :around_update,
       :after_update, :before_destroy, :around_destroy, :after_destroy
     ]
@@ -16,7 +17,7 @@ module ActiveResource
       extend ActiveModel::Callbacks
       include ActiveModel::Validations::Callbacks
 
-      define_model_callbacks :save, :create, :update, :destroy
+      define_model_callbacks :save, :reload, :create, :update, :destroy
     end
   end
 end

--- a/test/cases/callbacks_test.rb
+++ b/test/cases/callbacks_test.rb
@@ -101,6 +101,21 @@ class CallbacksTest < ActiveSupport::TestCase
     ], developer.history
   end
 
+  def test_reload
+    developer = Developer.find(1)
+    developer.reload
+    assert_equal [
+      [ :before_reload,               :method ],
+      [ :before_reload,               :proc   ],
+      [ :before_reload,               :object ],
+      [ :before_reload,               :block  ],
+      [ :after_reload,                :method ],
+      [ :after_reload,                :proc   ],
+      [ :after_reload,                :object ],
+      [ :after_reload,                :block  ]
+    ], developer.history
+  end
+
   def test_update
     developer = Developer.find(1)
     developer.save


### PR DESCRIPTION
This commit introduces three additional callbacks:

* `before_reload` - evaluated before re-fetching the resource's data with a `GET` request

* `after_reload` - evaluated after re-fetching the resource's data with a `GET` request

* `around_reload` - evaluated around re-fetching the resource's data with a `GET` request