### PR TITLE
Pass CI for `rails@8.1`

### DIFF
--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -776,7 +776,11 @@ class BaseTest < ActiveSupport::TestCase
   def test_collection_path_with_parameters
     assert_equal "/people.json?gender=male", Person.collection_path(gender: "male")
     assert_equal "/people.json?gender=false", Person.collection_path(gender: false)
-    assert_equal "/people.json?gender=", Person.collection_path(gender: nil)
+    if ActiveSupport::VERSION::MAJOR < 8 || ActiveSupport::VERSION::MINOR < 1
+      assert_equal "/people.json?gender=", Person.collection_path(gender: nil)
+    else
+      assert_equal "/people.json?gender", Person.collection_path(gender: nil)
+    end
 
     assert_equal "/people.json?gender=male", Person.collection_path("gender" => "male")
 
@@ -785,7 +789,11 @@ class BaseTest < ActiveSupport::TestCase
     assert Person.collection_path(gender: "male", student: true).include?("gender=male")
     assert Person.collection_path(gender: "male", student: true).include?("student=true")
 
-    assert_equal "/people.json?name%5B%5D=bob&name%5B%5D=your+uncle%2Bme&name%5B%5D=&name%5B%5D=false", Person.collection_path(name: ["bob", "your uncle+me", nil, false])
+    if ActiveSupport::VERSION::MAJOR < 8 || ActiveSupport::VERSION::MINOR < 1
+      assert_equal "/people.json?name%5B%5D=bob&name%5B%5D=your+uncle%2Bme&name%5B%5D=&name%5B%5D=false", Person.collection_path(name: ["bob", "your uncle+me", nil, false])
+    else
+      assert_equal "/people.json?name%5B%5D=bob&name%5B%5D=your+uncle%2Bme&name%5B%5D&name%5B%5D=false", Person.collection_path(name: ["bob", "your uncle+me", nil, false])
+    end
     assert_equal "/people.json?struct%5Ba%5D%5B%5D=2&struct%5Ba%5D%5B%5D=1&struct%5Bb%5D=fred", Person.collection_path(struct: { :a => [2, 1], "b" => "fred" })
   end
 

--- a/test/singleton_test.rb
+++ b/test/singleton_test.rb
@@ -41,7 +41,11 @@ class SingletonTest < ActiveSupport::TestCase
   def test_singleton_path_with_parameters
     assert_equal "/weather.json?degrees=fahrenheit", Weather.singleton_path(degrees: "fahrenheit")
     assert_equal "/weather.json?degrees=false", Weather.singleton_path(degrees: false)
-    assert_equal "/weather.json?degrees=", Weather.singleton_path(degrees: nil)
+    if ActiveSupport::VERSION::MAJOR < 8 || ActiveSupport::VERSION::MINOR < 1
+      assert_equal "/weather.json?degrees=", Weather.singleton_path(degrees: nil)
+    else
+      assert_equal "/weather.json?degrees", Weather.singleton_path(degrees: nil)
+    end
 
     assert_equal "/weather.json?degrees=fahrenheit", Weather.singleton_path("degrees" => "fahrenheit")
 
@@ -52,7 +56,11 @@ class SingletonTest < ActiveSupport::TestCase
     assert path.include?("lunar=true")
 
     path = Weather.singleton_path(days: ["monday", "saturday and sunday", nil, false])
-    assert_equal "/weather.json?days%5B%5D=monday&days%5B%5D=saturday+and+sunday&days%5B%5D=&days%5B%5D=false", path
+    if ActiveSupport::VERSION::MAJOR < 8 || ActiveSupport::VERSION::MINOR < 1
+      assert_equal "/weather.json?days%5B%5D=monday&days%5B%5D=saturday+and+sunday&days%5B%5D=&days%5B%5D=false", path
+    else
+      assert_equal "/weather.json?days%5B%5D=monday&days%5B%5D=saturday+and+sunday&days%5B%5D&days%5B%5D=false", path
+    end
 
     path = Inventory.singleton_path(product_id: 5)
     assert_equal "/products/5/inventory.json", path


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/53962

As of [abdbff5][], calls to [Hash#to_query][] with `nil` values will omit the joining `=` character.

This change resolves [CI failures][] for Rails past `rails@8.1` like:

```
  1) Failure:
BaseTest#test_collection_path_with_parameters [test/cases/base_test.rb:779]:
Expected: "/people.json?gender="
  Actual: "/people.json?gender"

  2) Failure:
SingletonTest#test_singleton_path_with_parameters [test/singleton_test.rb:44]:
Expected: "/weather.json?degrees="
  Actual: "/weather.json?degrees"
```

[abdbff5]: https://github.com/rails/rails/commit/abdbff56db0c0142027b3d674dd71b15f72da561
[Hash#to_query]: https://edgeapi.rubyonrails.org/classes/Hash.html#method-i-to_query
[CI failures]: https://github.com/rails/activeresource/actions/runs/12606260018/job/35136128961?pr=411#step:4:17