### PR TITLE
`ActiveResource::Singleton::CustomMethods` module to use `singleton_name` in path

### DIFF
--- a/lib/active_resource/singleton.rb
+++ b/lib/active_resource/singleton.rb
@@ -1,8 +1,41 @@
 # frozen_string_literal: true
 
 module ActiveResource
+  # === Custom REST methods
+  #
+  # Since simple CRUD/life cycle methods can't accomplish every task, Singleton Resources can also support
+  # defining custom REST methods. To invoke them, Active Resource provides the <tt>get</tt>,
+  # <tt>post</tt>, <tt>put</tt> and <tt>delete</tt> methods where you can specify a custom REST method
+  # name to invoke.
+  #
+  # Singleton resources use their <tt>singleton_name</tt> value as their default
+  # <tt>collection_name</tt> value when constructing the request's path.
+  #
+  #   # GET to report on the Inventory, i.e. GET /products/1/inventory/report.json.
+  #   Inventory.get(:report, product_id: 1)
+  #   # => [{:count => 'Manager'}, {:name => 'Clerk'}]
+  #
+  #   # DELETE to 'reset' an inventory, i.e. DELETE /products/1/inventory/reset.json.
+  #   Inventory.find(params: { product_id: 1 }).delete(:reset)
+  #
+  # For more information on using custom REST methods, see the
+  # ActiveResource::CustomMethods documentation.
   module Singleton
     extend ActiveSupport::Concern
+
+    module CustomMethods
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def collection_name
+          @collection_name || singleton_name
+        end
+      end
+
+      def custom_method_element_url(method_name, options = {})
+        "#{self.class.prefix(prefix_options)}#{self.class.collection_name}/#{method_name}#{self.class.format_extension}#{self.class.__send__(:query_string, options)}"
+      end
+    end
 
     module ClassMethods
       attr_writer :singleton_name


### PR DESCRIPTION
The problem
---

Active Resource's custom methods are operations outside of the
conventional collection of CRUD actions. For typical collections of
resources, custom methods operate on the collection itself. For example,
consider a custom `refresh` action for a `Product` resource triggered by
`POST` requests: `POST /products/:product_id/refresh`. The route
utilizes a `:product_id` dynamic segment to identify the `Product` in
question, and the path includes `/refresh` to signify the custom method
to perform.

The concept of a "singleton" resource is that there is only one singular
resource, and operations should consistently modify the same resource.
Since the resource is singular in nature, paths *do not* identify that
resource with an ID. For example, consider a singleton `Inventory`
resource that belongs to a `Product`. Its singleton path would be
`/products/:product_id/inventory`.

Prior to this commit, custom methods invoked by both *instances* and
*classes* of singleton resources ignored the "singleton" nature of
route, and use pluralize nouns instead of singular ones.

For example, consider calls to custom "report" and "reset" methods for
an instance of a singleton `Inventory` resource:

```ruby
class Inventory < ActiveResource::Base
  include ActiveResource::Singleton
end

inventory = Inventory.find(params: { product_id: 1 }) # => GET /products/1/inventory.json

  # BEFORE
inventory.get(:report, product_id: 1)   # => GET /products/1/inventories/report.json
inventory.delete(:reset, product_id: 1) # => DELETE /products/1/inventories/reset.json
```

Note the `/inventories/` portion of the URL prefix. The same occurs for
class methods. For example, consider calls to the same custom "report"
and "reset" routes for a singleton `Inventory` resource class:

```ruby
 # BEFORE
Inventory.get(:report, product_id: 1)   # => GET /products/1/inventories/report.json
Inventory.delete(:reset, product_id: 1) # => DELETE /products/1/inventories/reset.json
```

The proposal
---

In order to make "singleton" resources behave more consistently with a
singular mental model, this commit proposes that Active Resource change
instance-level custom methods (through the same `get`, `post`, `put`,
`patch`, and `delete` style methods) to use the singular singleton name
in their paths.

When declaring a resource as a "singleton" (through including the
`ActiveResource::Singleton` module), ensure that subsequent calls to
class-level custom methods (through the `get`, `post`, `put`, `patch`,
and `delete` class and instance methods) use the singleton name by
default.

```ruby
Inventory.include ActiveResource::Singleton::CustomMethods

  # AFTER
Inventory.get(:report, product_id: 1)   # => GET /products/1/inventory/report.json
Inventory.delete(:reset, product_id: 1) # => DELETE /products/1/inventory/reset.json
```

When a `collection_name` is explicitly configured, use that value
instead of the `singleton_name` default.

Apply the same changes to instances of singleton resources:

```ruby
inventory = Inventory.find(params: { product_id: 1 }) # => GET /products/1/inventory.json

  # AFTER
inventory.get(:report)    # => GET /products/1/inventory/report.json
inventory.delete(:reset)  # => DELETE /products/1/inventory/reset.json
```

