### PR TITLE
Configure `ActiveResource::Base.casing`

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -37,6 +37,7 @@ module ActiveResource
 
   autoload :Base
   autoload :Callbacks
+  autoload :Casings
   autoload :Connection
   autoload :CustomMethods
   autoload :Formats

--- a/lib/active_resource/casings.rb
+++ b/lib/active_resource/casings.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  module Casings
+    extend ActiveSupport::Autoload
+
+    autoload :CamelcaseCasing, "active_resource/casings/camelcase_casing"
+    autoload :NoneCasing, "active_resource/casings/none_casing"
+    autoload :UnderscoreCasing, "active_resource/casings/underscore_casing"
+
+    # Lookup the casing class from a reference symbol. Example:
+    #
+    #   ActiveResource::Casings[:camelcase]   # => ActiveResource::Casings::CamelcaseCasing
+    #   ActiveResource::Casings[:none]        # => ActiveResource::Casings::NoneCasing
+    #   ActiveResource::Casings[:underscore]  # => ActiveResource::Casings::UnderscoreCasing
+    def self.[](name)
+      const_get(ActiveSupport::Inflector.camelize(name.to_s) + "Casing")
+    end
+  end
+end

--- a/lib/active_resource/casings/camelcase_casing.rb
+++ b/lib/active_resource/casings/camelcase_casing.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  module Casings
+    class CamelcaseCasing < UnderscoreCasing
+      def initialize(first_letter = :lower)
+        super()
+        @first_letter = first_letter
+      end
+
+      private
+        def encode_key(key)
+          key.camelcase(@first_letter)
+        end
+    end
+  end
+end

--- a/lib/active_resource/casings/none_casing.rb
+++ b/lib/active_resource/casings/none_casing.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  module Casings
+    class NoneCasing
+      def encode(key)
+        transform_key(key, &method(:encode_key))
+      end
+
+      def decode(key)
+        transform_key(key, &method(:decode_key))
+      end
+
+      private
+        def encode_key(key)
+          key
+        end
+
+        def decode_key(key)
+          key
+        end
+
+        def transform_key(key)
+          transformed_key = yield key.to_s
+
+          key.is_a?(Symbol) ? transformed_key.to_sym : transformed_key
+        end
+    end
+  end
+end

--- a/lib/active_resource/casings/underscore_casing.rb
+++ b/lib/active_resource/casings/underscore_casing.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  module Casings
+    class UnderscoreCasing < NoneCasing
+      private
+        def encode_key(key)
+          key.underscore
+        end
+
+        def decode_key(key)
+          key.underscore
+        end
+    end
+  end
+end

--- a/test/cases/collection_test.rb
+++ b/test/cases/collection_test.rb
@@ -105,6 +105,23 @@ class CollectionInheritanceTest < ActiveSupport::TestCase
     assert_equal PaginatedPost.find(:all).next_page, @posts_hash[:next_page]
   end
 
+  def test_with_camelcase
+    PaginatedPost.casing = :camelcase
+    posts_hash = { "results" => [@post], "nextPage" => "/paginated_posts.json?page=2" }
+    ActiveResource::HttpMock.respond_to.get "/paginated_posts.json", {}, posts_hash.to_json
+
+    assert_equal PaginatedPost.find(:all).next_page, posts_hash["nextPage"]
+  ensure
+    PaginatedPost.casing = nil
+  end
+
+  def test_with_underscore
+    PaginatedPost.casing = :underscore
+    assert_equal PaginatedPost.find(:all).next_page, @posts_hash[:next_page]
+  ensure
+    PaginatedPost.casing = nil
+  end
+
   def test_first_or_create
     post = PaginatedPost.where(title: "test").first_or_create
     assert post.valid?

--- a/test/cases/finder_test.rb
+++ b/test/cases/finder_test.rb
@@ -63,6 +63,26 @@ class FinderTest < ActiveSupport::TestCase
     assert_kind_of StreetAddress, addresses.first
   end
 
+  def test_where_with_clauses_and_camelcase_casing
+    Person.casing = :camelcase
+    ActiveResource::HttpMock.respond_to { |m| m.get "/people.json?firstName=david", {}, @people_david }
+    people = Person.where(first_name: "david")
+    assert_equal 1, people.size
+    assert_kind_of Person, people.first
+  ensure
+    Person.casing = nil
+  end
+
+  def test_where_with_clauses_and_underscore_casing
+    Person.casing = :underscore
+    ActiveResource::HttpMock.respond_to { |m| m.get "/people.json?first_name=david", {}, @people_david }
+    people = Person.where(first_name: "david")
+    assert_equal 1, people.size
+    assert_kind_of Person, people.first
+  ensure
+    Person.casing = nil
+  end
+
   def test_where_with_clause_in
     ActiveResource::HttpMock.respond_to { |m| m.get "/people.json?id%5B%5D=2", {}, @people_david }
     people = Person.where(id: [2])


### PR DESCRIPTION
The `Base.casing` configuration controls how resource classes handle API responses with cases that differ from Ruby's `camel_case` idioms.

For example, setting `casing = :camelcase` will configure the resource to transform inbound camelCase JSON to under_score when loading API data:

```ruby
payload = {
  id: 1,
  firstName: "Matz"
}.as_json

person = Person.load(payload)
person.first_name # => "Matz"
```

Similarly, the casing configures the resource to transform outbound attributes from the intermediate `under_score` idiomatic Ruby names to the original `camelCase` names:

```ruby
person.first_name # => "Matz"
person.encode # => "{\"id\":1, \"firstName\":\"Matz\"}"
```

By default, resources are configured with `casing = :none`, which does not transform keys. In addition to `:none` and `:camelcase`, the `:underscore` configuration ensures idiomatic Ruby names throughout.

When left unconfigured, `casing = :camelcase` will transform keys with a lower case first letter. To transform with upper case letters, construct an instance of `ActiveResource::Casings::CamelcaseCasing`:

```ruby
Person.casing = ActiveResource::Casings::CamelcaseCasing.new(:upper)

payload = {
  Id: 1,
  FirstName: "Matz"
}.as_json

person = Person.load(payload)
person.first_name # => "Matz"

person.encode #=> "{\"Id\":1,\"FirstName\":\"Matz\"}"
```

Casing transformations are also applied to query parameters built from `.where` clauses:

```ruby
Person.casing = :camelcase

Person.where(first_name: "Matz") # => GET /people.json?firstName=Matz
```