### PR TITLE
Fix `ActiveResource::HttpMock.enable_net_connection!` when Connection is first used

### DIFF
--- a/lib/active_resource/http_mock.rb
+++ b/lib/active_resource/http_mock.rb
@@ -375,11 +375,11 @@ module ActiveResource
         end
 
         def unstub_http?
-          HttpMock.net_connection_enabled? && defined?(@http) && @http.kind_of?(HttpMock)
+          HttpMock.net_connection_enabled? && (!defined?(@http) || @http.kind_of?(HttpMock))
         end
 
         def stub_http?
-          HttpMock.net_connection_disabled? && defined?(@http) && @http.kind_of?(Net::HTTP)
+          HttpMock.net_connection_disabled? && (!defined?(@http) || @http.kind_of?(Net::HTTP))
         end
       end
   end

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -312,6 +312,13 @@ class ConnectionTest < ActiveSupport::TestCase
     end
   end
 
+  def test_enable_net_connection_first_time
+    keep_net_connection_status do
+      ActiveResource::HttpMock.enable_net_connection!
+      assert @conn.send(:http).kind_of?(Net::HTTP)
+    end
+  end
+
   def test_disable_net_connection
     keep_net_connection_status do
       ActiveResource::HttpMock.enable_net_connection!


### PR DESCRIPTION
`ActiveResource::HttpMock.enable_net_connection!` was ignored on the first call to `ActiveResource::Connection#http`.