### PR TITLE
Fix private klass method warning

### DIFF
--- a/lib/active_resource/active_job_serializer.rb
+++ b/lib/active_resource/active_job_serializer.rb
@@ -18,9 +18,8 @@ module ActiveResource
       end
     end
 
-    private
-      def klass
-        ActiveResource::Base
-      end
+    def klass
+      ActiveResource::Base
+    end
   end
 end


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/55583, we warn if the klass method is not public.