### PR TITLE
Make klass method public

### DIFF
--- a/lib/active_resource/active_job_serializer.rb
+++ b/lib/active_resource/active_job_serializer.rb
@@ -18,6 +18,7 @@ module ActiveResource
       end
     end
 
+    # Rails now expects this method to be public
     def klass
       ActiveResource::Base
     end


### PR DESCRIPTION
Rails now expects this method to be public, this is failing the Rails upgrade in core