### PR TITLE
Bump version from 6.1.4 to 6.1.5

### DIFF
--- a/lib/active_resource/version.rb
+++ b/lib/active_resource/version.rb
@@ -4,7 +4,7 @@ module ActiveResource
   module VERSION # :nodoc:
     MAJOR = 6
     MINOR = 1
-    TINY  = 4
+    TINY  = 5
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
To capture the warning fix in https://github.com/rails/activeresource/pull/427/files