### PR TITLE
`Coder#load`: Conditionally call `Formats.remove_root`

### DIFF
--- a/lib/active_resource/coder.rb
+++ b/lib/active_resource/coder.rb
@@ -70,6 +70,8 @@ module ActiveResource
       return if value.nil?
       value = resource_class.format.decode(value) if value.is_a?(String)
       raise ArgumentError.new("expected value to be Hash, but was #{value.class}") unless value.is_a?(Hash)
+      value = Formats.remove_root(value) if value.keys.first.to_s == resource_class.element_name
+
       resource_class.new(value, value[resource_class.primary_key])
     end
   end


### PR DESCRIPTION
Follow-up to [#420][]

Problem
---

While the `Coder` class and `Serialization` module aim to comply with Active Record, there's still potential for that compatibility to drift of break without sufficient test coverage.

The `Coder#load` implementation does not support inferring the correct `@persisted` value from payloads with root-level keys. For example, `{ "person": { "id": 1 } }` will not be inferred as persisted in the same way that `{ "id": 1 }` will.

Proposal
---

To resolve the `@persisted` value, call `Format.remove_root` to ensure that the payload consists of only attributes.

[#420]: https://github.com/rails/activeresource/pull/420