### PR TITLE
Raise `ActiveResource::UnavailableForLegalReasons` for HTTP 451

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -221,6 +221,7 @@ module ActiveResource
   # * 412 - ActiveResource::PreconditionFailed
   # * 422 - ActiveResource::ResourceInvalid (rescued by save as validation errors)
   # * 429 - ActiveResource::TooManyRequests
+  # * 451 - ActiveResource::UnavailableForLegalReasons
   # * 401..499 - ActiveResource::ClientError
   # * 500..599 - ActiveResource::ServerError
   # * Other - ActiveResource::ConnectionError

--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -163,6 +163,8 @@ module ActiveResource
           raise(ResourceInvalid.new(response))
         when 429
           raise(TooManyRequests.new(response))
+        when 451
+          raise(UnavailableForLegalReasons.new(response))
         when 401...500
           raise(ClientError.new(response))
         when 500...600

--- a/lib/active_resource/exceptions.rb
+++ b/lib/active_resource/exceptions.rb
@@ -88,6 +88,10 @@ module ActiveResource
   class TooManyRequests < ClientError # :nodoc:
   end
 
+  # 451 Unavailable For Legal Reasons
+  class UnavailableForLegalReasons < ClientError # :nodoc:
+  end
+
   # 5xx Server Error
   class ServerError < ConnectionError # :nodoc:
   end

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -101,6 +101,9 @@ class ConnectionTest < ActiveSupport::TestCase
     # 429 is too many requests
     assert_response_raises ActiveResource::TooManyRequests, 429
 
+    # 451 is unavailable for legal reasons
+    assert_response_raises ActiveResource::UnavailableForLegalReasons, 451
+
     # 4xx are client errors.
     [ 402, 499 ].each do |code|
       assert_response_raises ActiveResource::ClientError, code


### PR DESCRIPTION
Add an explicit `ActiveResource::UnavailableForLegalReasons` error class and `when …` clause for [451 Unavailable For Legal Reasons][] HTTP responses.

[451 Unavailable For Legal Reasons]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/451