### PR TITLE
Integrate with `ActiveModel::Dirty`

### DIFF
--- a/lib/active_resource.rb
+++ b/lib/active_resource.rb
@@ -41,6 +41,7 @@ module ActiveResource
   autoload :Coder
   autoload :Connection
   autoload :CustomMethods
+  autoload :Dirty
   autoload :Formats
   autoload :HttpMock
   autoload :Rescuable

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -129,6 +129,34 @@ module ActiveResource
   #   Person.format.decode(person.encode)
   #   # => {"first_name"=>"First", "last_name"=>"Last"}
   #
+  # === Attribute change tracking
+  #
+  # Active Resources track local attribute changes by integrating with
+  # ActiveModel::Dirty.
+  #
+  # Changes are discard when Active Resource successfuly saves the resource
+  # to the remote server or reloads data from the remote server:
+  #
+  #   person = Person.find(1)
+  #   person.name           # => "Matz"
+  #   person.name = "Changed"
+  #
+  #   person.name_changed?  # => true
+  #   person.name_changes   # => ["Matz", "Changed"]
+  #   person.save
+  #
+  #   person.name_changed?  # => false
+  #   person.name_changes   # => []
+  #
+  #   person.name = "Matz"
+  #   person.name_changed?  # => true
+  #   person.name_changes   # => ["Changed", "Matz"]
+  #
+  #   person.reload
+  #   person.name           # => "Changed"
+  #   person.name_changed?  # => false
+  #   person.name_changes   # => []
+  #
   # === Custom REST methods
   #
   # Since simple CRUD/life cycle methods can't accomplish every task, Active Resource also supports
@@ -463,6 +491,7 @@ module ActiveResource
             @schema[k] = v
             @known_attributes << k
           end
+          define_attribute_methods @known_attributes
 
           @schema
         else
@@ -492,6 +521,7 @@ module ActiveResource
           # purposefully nulling out the schema
           @schema = nil
           @known_attributes = []
+          undefine_attribute_methods
           return
         end
 
@@ -1730,13 +1760,16 @@ module ActiveResource
       name = self.class.primary_key if name == "id" && self.class.primary_key
       @attributes[name]
     end
+    alias_method :attribute, :read_attribute
 
     def write_attribute(attr_name, value)
       name = attr_name.to_s
 
       name = self.class.primary_key if name == "id" && self.class.primary_key
+      attribute_will_change!(name) if known_attributes.include?(name) && @attributes[name] != value
       @attributes[name] = value
     end
+    alias_method :attribute=, :write_attribute
 
     protected
       def attributes=(attrs)
@@ -1908,6 +1941,7 @@ module ActiveResource
     extend ActiveResource::Associations
 
     include Callbacks, CustomMethods, Validations, Serialization
+    include Dirty
     include ActiveModel::Conversion
     include ActiveModel::ForbiddenAttributesProtection
     include ActiveModel::Serializers::JSON

--- a/lib/active_resource/dirty.rb
+++ b/lib/active_resource/dirty.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveResource
+  module Dirty # :nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      include ActiveModel::Dirty
+
+      after_save :changes_applied
+      after_reload :clear_changes_information
+
+      private
+
+      def mutations_from_database
+        @mutations_from_database ||= ActiveModel::ForcedMutationTracker.new(self)
+      end
+
+      def forget_attribute_assignments
+        # no-op
+      end
+    end
+  end
+end

--- a/test/cases/dirty_test.rb
+++ b/test/cases/dirty_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "fixtures/person"
+
+class DirtyTest < ActiveSupport::TestCase
+  setup do
+    setup_response
+    @previous_schema = Person.schema
+  end
+
+  teardown do
+    Person.schema = @previous_schema
+  end
+
+  test "is clean when built" do
+    resource = Person.new
+
+    assert_empty resource.changes
+  end
+
+  test "is clean when reloaded" do
+    Person.schema do
+      attribute :name, :string
+    end
+
+    resource = Person.find(1)
+    resource.name = "changed"
+
+    assert_changes -> { resource.name_changed? }, from: true, to: false do
+      resource.reload
+    end
+  end
+
+  test "is clean after create" do
+    Person.schema do
+      attribute :name, :string
+    end
+
+    resource = Person.new name: "changed"
+    ActiveResource::HttpMock.respond_to.post "/people.json", {}, { id: 1, name: "changed" }.to_json
+
+    assert_changes -> { resource.name_changed? }, from: true, to: false do
+      resource.save
+    end
+    assert_empty resource.changes
+  end
+
+  test "is clean after update" do
+    Person.schema do
+      attribute :name, :string
+    end
+
+    resource = Person.find(1)
+    ActiveResource::HttpMock.respond_to.put "/people/1.json", {}, { id: 1, name: "changed" }.to_json
+
+    assert_changes -> { resource.name_changed? }, from: true, to: false do
+      resource.update(name: "changed")
+    end
+    assert_empty resource.changes
+  end
+
+  test "is dirty when known attribute changes are unsaved" do
+    Person.schema do
+      attribute :name, :string
+    end
+    expected_changes = {
+      "name" => [ nil, "known" ]
+    }
+
+    resource = Person.new name: "known"
+
+    assert_predicate resource, :name_changed?
+    assert_equal expected_changes, resource.changes
+  end
+
+  test "is not dirty when unknown attribute changes are unsaved" do
+    resource = Person.new name: "unknown"
+
+    assert_not_predicate resource, :name_changed?
+    assert_empty resource.changes
+  end
+end


### PR DESCRIPTION
Related to https://github.com/rails/activeresource/issues/308
Supports https://github.com/rails/activeresource/issues/103
Supports https://github.com/rails/activeresource/issues/169

Introduce the `ActiveResource::Dirty` module to extend the [ActiveModel::Dirty][] module with a variety of internal overrides.

Like Active Record, Active Resource has two mechanisms to affect dirty state:

* persistence (via `#save` and `#update`)
* reloading (via `#reload`)

Custom methods and other instances of direct interaction with the underlying HTTP connection will require ad hoc invocations of [ActiveModel::Dirty][] methods like `*_will_change!` and `clear_changes_information`.

Currently, only attributes declared by a resource's schema are dirty-tracked.

[ActiveModel::Dirty]: https://api.rubyonrails.org/classes/ActiveModel/Dirty.html