### PR TITLE
Associations: Support `:primary_key` and `:foreign_key`

### DIFF
--- a/lib/active_resource/associations/builder/has_many.rb
+++ b/lib/active_resource/associations/builder/has_many.rb
@@ -2,6 +2,8 @@
 
 module ActiveResource::Associations::Builder
   class HasMany < Association
+    self.valid_options += [ :primary_key, :foreign_key ]
+
     self.macro = :has_many
 
     def build

--- a/lib/active_resource/associations/builder/has_one.rb
+++ b/lib/active_resource/associations/builder/has_one.rb
@@ -2,6 +2,8 @@
 
 module ActiveResource::Associations::Builder
   class HasOne < Association
+    self.valid_options += [ :primary_key, :foreign_key ]
+
     self.macro = :has_one
 
     def build


### PR DESCRIPTION
The problem
---

Some `has_many` and `has_one` associations provided by APIs are "joined" by properties other than their `id` (or an overridden `primary_key`).

The proposal
---

By default, continue to infer the `:foreign_key` as `self.class.element_name + "_id"` and its `:primary_key` from the value of its primary key (returned by the `id` method).

When necessary, `has_many` declarations can declare `:primary_key` and `:foreign_key` options in the same style as [Active Record's `has_many` associations][has_many].

[has_many]: https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many