### PR TITLE
Validations: Default context based on persistence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "rubocop-performance"
 gem "rubocop-rails"
 gem "rubocop-rails-omakase"
 
+gem "minitest", "< 6"
 gem "minitest-bisect"
 
 gemspec

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1472,6 +1472,12 @@ module ActiveResource
     # is Json for the final object as it looked after the \save (which would include attributes like +created_at+
     # that weren't part of the original submit).
     #
+    # With <tt>save</tt> validations run by default. If any of them fail
+    # ActiveResource::ResourceInvalid gets raised, and nothing is POSTed to
+    # the remote system. To skip validations, pass <tt>validate: false</tt>. To
+    # validate withing a custom context, pass the <tt>:context</tt> option.
+    # See ActiveResource::Validations for more information.
+    #
     # There's a series of callbacks associated with <tt>save</tt>. If any
     # of the <tt>before_*</tt> callbacks throw +:abort+ the action is
     # cancelled and <tt>save</tt> raises ActiveResource::ResourceInvalid.
@@ -1484,7 +1490,7 @@ module ActiveResource
     #   my_company.new? # => false
     #   my_company.size = 10
     #   my_company.save # sends PUT /companies/1 (update)
-    def save
+    def save(...)
       run_callbacks :save do
         new? ? create : _update
       end
@@ -1495,16 +1501,17 @@ module ActiveResource
     # If the resource is new, it is created via +POST+, otherwise the
     # existing resource is updated via +PUT+.
     #
-    # With <tt>save!</tt> validations always run. If any of them fail
+    # With <tt>save!</tt> validations run by default. If any of them fail
     # ActiveResource::ResourceInvalid gets raised, and nothing is POSTed to
-    # the remote system.
+    # the remote system. To skip validations, pass <tt>validate: false</tt>. To
+    # validate withing a custom context, pass the <tt>:context</tt> option.
     # See ActiveResource::Validations for more information.
     #
     # There's a series of callbacks associated with <tt>save!</tt>. If any
     # of the <tt>before_*</tt> callbacks throw +:abort+ the action is
     # cancelled and <tt>save!</tt> raises ActiveResource::ResourceInvalid.
-    def save!
-      save || raise(ResourceInvalid.new(nil, self))
+    def save!(...)
+      save(...) || raise(ResourceInvalid.new(nil, self))
     end
 
     ##

--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -283,7 +283,7 @@ module ActiveResource
       # ones. Otherwise we get an endless loop and can never change the
       # fields so as to make the resource valid.
       @remote_errors = nil
-      if perform_validation && valid? || !perform_validation
+      if perform_validation && valid?(options[:context]) || !perform_validation
         save_without_validation
         true
       else

--- a/lib/active_resource/validations.rb
+++ b/lib/active_resource/validations.rb
@@ -314,6 +314,14 @@ module ActiveResource
     # saved.
     # Remote errors can only be cleared by trying to re-save the resource.
     #
+    # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
+    # {new_record?}[rdoc-ref:Base#new_record?] is +true+, and to <tt>:update</tt> if it is not.
+    # If the argument is an array of contexts, <tt>post.valid?([:create, :update])</tt>, the validations are
+    # run within multiple contexts.
+    #
+    # \Validations with no <tt>:on</tt> option will run no matter the context. \Validations with
+    # some <tt>:on</tt> option will only run in the specified context.
+    #
     # ==== Examples
     #   my_person = Person.create(params[:person])
     #   my_person.valid?
@@ -324,6 +332,8 @@ module ActiveResource
     #   # => false
     #
     def valid?(context = nil)
+      context ||= new_record? ? :create : :update
+
       run_callbacks :validate do
         super
         load_remote_errors(@remote_errors, true) if defined?(@remote_errors) && @remote_errors.present?

--- a/test/cases/validations_test.rb
+++ b/test/cases/validations_test.rb
@@ -32,10 +32,28 @@ class ValidationsTest < ActiveSupport::TestCase
     assert_raise(ActiveResource::ResourceInvalid) { p.save! }
   end
 
+  def test_save_with_context
+    p = new_project(summary: nil)
+    assert_not p.save(context: :completed)
+    assert_equal [ "can't be blank" ], p.errors.messages_for(:summary)
+  end
+
+  def test_save_bang_with_context
+    p = new_project(summary: nil)
+    assert_raise(ActiveResource::ResourceInvalid) { p.save!(context: :completed) }
+    assert_equal [ "can't be blank" ], p.errors.messages_for(:summary)
+  end
+
   def test_save_without_validation
     p = new_project(name: nil)
     assert_not p.save
     assert p.save(validate: false)
+  end
+
+  def test_save_bang_without_validation
+    p = new_project(name: nil)
+    assert_raises(ActiveResource::ResourceInvalid) { p.save! }
+    assert p.save!(validate: false)
   end
 
   def test_validate_callback
@@ -54,6 +72,14 @@ class ValidationsTest < ActiveSupport::TestCase
     project = Project.new(description: "123456789012345")
     assert_not project.valid?
     assert_equal [ "is too long (maximum is 10 characters)" ], project.errors[:description]
+  end
+
+  def test_validation_context
+    project = new_project(summary: "")
+
+    assert_predicate project, :valid?
+    assert_not project.valid?(:completed)
+    assert_equal [ "can't be blank" ], project.errors.messages_for(:summary)
   end
 
   def test_invalid_method

--- a/test/fixtures/project.rb
+++ b/test/fixtures/project.rb
@@ -11,6 +11,7 @@ class Project < ActiveResource::Base
   validates :name, presence: true
   validates :description, presence: false, length: { maximum: 10 }
   validate :description_greater_than_three_letters
+  validates :summary, presence: { on: :completed }
 
   # to test the validate *callback* works
   def description_greater_than_three_letters


### PR DESCRIPTION
Depends on https://github.com/rails/activeresource/pull/468
===

This commit proposed that Active Resource follow the same pattern as
[Active Record Validations][], namely that an instance's default
validation context will be `:create` when the record **is not yet**
persisted and `:update` when the record **is** persisted.

[Active Record Validations]: https://api.rubyonrails.org/v8.1/classes/ActiveRecord/Validations.html#method-i-valid-3F
