### PR TITLE
Fix circular require warning in railtie

### DIFF
--- a/lib/active_resource/railtie.rb
+++ b/lib/active_resource/railtie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "active_resource"
+require "active_resource" unless defined?(ActiveResource)
 require "rails"
 
 module ActiveResource


### PR DESCRIPTION
## Summary

The railtie unconditionally required `active_resource`, which created a circular dependency when loaded from `active_resource.rb`:

```
active_resource.rb
  → active_resource/railtie.rb
    → active_resource.rb (circular!)
```

This produced the following warning:

```
warning: loading in progress, circular require considered harmful -
  .../activeresource/lib/active_resource.rb
    from .../activeresource/lib/activeresource.rb:3:in '<top (required)>'
    from .../activeresource/lib/active_resource.rb:46:in '<top (required)>'
    from .../activeresource/lib/active_resource/railtie.rb:3:in '<top (required)>'
```

Guard the require so it only loads `active_resource` when the `ActiveResource` module isn't already defined. This avoids the circular require in the normal load path (where `active_resource.rb` loads the railtie) while still supporting the direct `require "active_resource/railtie"` entry point used by some applications.