### PR TITLE
Add support for HTTP `QUERY` method

### DIFF
--- a/lib/active_resource/connection.rb
+++ b/lib/active_resource/connection.rb
@@ -5,6 +5,19 @@ require "net/https"
 require "date"
 require "time"
 
+# Define the Net::HTTP::Query class for runtimes where it is not yet available.
+#
+# See https://github.com/ruby/net-http/pull/309
+# See https://www.rfc-editor.org/rfc/rfc10008.html
+#
+unless Net::HTTP.const_defined?(:Query)
+  class Net::HTTP::Query < Net::HTTPRequest
+    METHOD = "QUERY"
+    REQUEST_HAS_BODY = true
+    RESPONSE_HAS_BODY = true
+  end
+end
+
 module ActiveResource
   # Class to handle connections to remote web services.
   # This class is used by ActiveResource::Base to interface with REST
@@ -12,6 +25,7 @@ module ActiveResource
   class Connection
     HTTP_FORMAT_HEADER_NAMES = {
       get: "Accept",
+      query: "Content-Type",
       put: "Content-Type",
       post: "Content-Type",
       patch: "Content-Type",
@@ -20,6 +34,7 @@ module ActiveResource
     }
     HTTP_METHODS = {
       get: Net::HTTP::Get,
+      query: Net::HTTP::Query,
       put: Net::HTTP::Put,
       post: Net::HTTP::Post,
       patch: Net::HTTP::Patch,
@@ -89,6 +104,16 @@ module ActiveResource
     # Used to get (find) resources.
     def get(path, headers = {})
       with_auth { request(:get, path, headers) }
+    end
+
+    # Executes a QUERY request (see the HTTP QUERY method,
+    # https://www.rfc-editor.org/rfc/rfc10008.html, if unfamiliar).
+    # Used to get (find) resources by transmitting the query in the request
+    # +body+ instead of the request URI. Like GET, QUERY is safe and idempotent,
+    # but it accepts a request body so that larger or more complex queries can be
+    # expressed without encoding them into the path.
+    def query(path, body = "", headers = {})
+      with_auth { request(:query, path, body.to_s, headers) }
     end
 
     # Executes a DELETE request (see HTTP protocol documentation if unfamiliar).

--- a/lib/active_resource/custom_methods.rb
+++ b/lib/active_resource/custom_methods.rb
@@ -61,6 +61,23 @@ module ActiveResource
           derooted.is_a?(Array) ? derooted.map { |e| Formats.remove_root(e) } : derooted
         end
 
+        # Invokes a QUERY to a given custom REST method. Like GET, QUERY is safe
+        # and idempotent, but the query is transmitted in the request +body+
+        # rather than the request URI. For example:
+        #
+        #   Person.query(:search, {}, { name: "Ryan" }.to_json)  # QUERY /people/search.json
+        #   # => [{:id => 1, :name => 'Ryan'}]
+        #
+        # Note: the objects returned from this method are not automatically converted
+        # into ActiveResource::Base instances - they are ordinary Hashes. If you are expecting
+        # ActiveResource::Base instances, use the <tt>find</tt> class method with the
+        # <tt>:from</tt> option.
+        def query(custom_method_name, options = {}, body = "")
+          hashified = format.decode(connection.query(custom_method_collection_url(custom_method_name, options), body, headers).body)
+          derooted  = Formats.remove_root(hashified)
+          derooted.is_a?(Array) ? derooted.map { |e| Formats.remove_root(e) } : derooted
+        end
+
         def post(custom_method_name, options = {}, body = "")
           connection.post(custom_method_collection_url(custom_method_name, options), body, headers)
         end
@@ -93,6 +110,10 @@ module ActiveResource
 
     def get(method_name, options = {})
       self.class.format.decode(connection.get(custom_method_element_url(method_name, options), self.class.headers).body)
+    end
+
+    def query(method_name, options = {}, body = "")
+      self.class.format.decode(connection.query(custom_method_element_url(method_name, options), body, self.class.headers).body)
     end
 
     def post(method_name, options = {}, body = nil)

--- a/lib/active_resource/http_mock.rb
+++ b/lib/active_resource/http_mock.rb
@@ -17,8 +17,8 @@ module ActiveResource
   #
   #   mock.http_method(path, request_headers = {}, body = nil, status = 200, response_headers = {})
   #
-  # * <tt>http_method</tt> - The HTTP method to listen for. This can be +get+, +post+, +patch+, +put+, +delete+ or
-  #   +head+.
+  # * <tt>http_method</tt> - The HTTP method to listen for. This can be +get+, +post+, +patch+, +put+, +delete+,
+  #   +head+, or +query+.
   # * <tt>path</tt> - A string, starting with a "/", defining the URI that is expected to be
   #   called.
   # * <tt>request_headers</tt> - Headers that are expected along with the request. This argument uses a
@@ -82,7 +82,7 @@ module ActiveResource
         @responses = responses
       end
 
-      [ :post, :patch, :put, :get, :delete, :head ].each do |method|
+      [ :post, :patch, :put, :get, :delete, :head, :query ].each do |method|
         # def post(path, request_headers = {}, body = nil, status = 200, response_headers = {}, options: {})
         #   @responses[Request.new(:post, path, nil, request_headers, options)] = Response.new(body || "", status, response_headers)
         # end
@@ -267,7 +267,7 @@ module ActiveResource
     end
 
     # body?       methods
-    { true  => %w[post patch put],
+    { true  => %w[post patch put query],
       false => %w[get delete head] }.each do |has_body, methods|
       methods.each do |method|
         # def post(path, body, headers, options = {})

--- a/test/cases/base/custom_methods_test.rb
+++ b/test/cases/base/custom_methods_test.rb
@@ -44,6 +44,8 @@ class CustomMethodsTest < ActiveSupport::TestCase
       mock.get    "/products/1/inventories/1/shallow.json", {}, @inventory
       mock.put    "/products/1/inventories/1/promote.json?name=Warehouse", {}, nil, 204
       mock.delete "/products/1/inventories/1/deactivate.json", {}, nil, 200
+      mock.query  "/people/search.json", {}, @matz_array
+      mock.query  "/people/1/similar.json", {}, @matz
     end
 
     Person.user = nil
@@ -89,6 +91,16 @@ class CustomMethodsTest < ActiveSupport::TestCase
                   "id" => 1, "street" => "12345 Street", "zip" => "27519"
     assert_equal ActiveResource::Response.new("", 204, {}),
                    StreetAddress.find(1, params: { person_id: 1 }).put(:normalize_phone, locale: "US")
+  end
+
+  def test_custom_collection_query_method
+    # QUERY against a collection URL, transmitting the query in the request body
+    assert_equal([ { "id" => 1, "name" => "Matz" } ], Person.query(:search, {}, { name: "Matz" }.to_json))
+  end
+
+  def test_custom_element_query_method
+    # QUERY against an element URL
+    assert_equal({ "id" => 1, "name" => "Matz" }, Person.find(1).query(:similar, {}, { name: "Matz" }.to_json))
   end
 
   def test_custom_new_element_method

--- a/test/cases/connection_test.rb
+++ b/test/cases/connection_test.rb
@@ -31,6 +31,8 @@ class ConnectionTest < ActiveSupport::TestCase
       mock.post   "/people.json",   {}, nil, 201, "Location" => "/people/5.json"
       mock.post   "/members.json",  {}, @header, 201, "Location" => "/people/6.json"
       mock.head   "/people/1.json", {}, nil, 200
+      mock.query  "/people/search.json", {}, @people
+      mock.query  "/members/search.json", @header, @david
     end
   end
 
@@ -186,6 +188,17 @@ class ConnectionTest < ActiveSupport::TestCase
     response = @conn.head("/people/1.json")
     assert response.body.blank?
     assert_equal 200, response.code
+  end
+
+  def test_query
+    people = decode(@conn.query("/people/search.json", { name: "Matz" }.to_json))
+    assert_equal "Matz", people.dig(0, "person", "name")
+    assert_equal "David", people.dig(1, "person", "name")
+  end
+
+  def test_query_with_header
+    david = decode(@conn.query("/members/search.json", { name: "David" }.to_json, @header))
+    assert_equal "David", david["name"]
   end
 
   def test_get_with_header

--- a/test/cases/http_mock_test.rb
+++ b/test/cases/http_mock_test.rb
@@ -34,7 +34,7 @@ class HttpMockTest < ActiveSupport::TestCase
     end
   end
 
-  [ :post, :patch, :put, :get, :delete, :head ].each do |method|
+  [ :post, :patch, :put, :get, :delete, :head, :query ].each do |method|
     test "responds to simple #{method} request" do
       ActiveResource::HttpMock.respond_to do |mock|
         mock.send(method, "/people/1", { FORMAT_HEADER[method] => "application/json" }, "Response")
@@ -281,7 +281,7 @@ class HttpMockTest < ActiveSupport::TestCase
   end
 
   def request(method, path, headers = {}, body = nil)
-    if method.in?([ :patch, :put, :post ])
+    if method.in?([ :patch, :put, :post, :query ])
       @http.send(method, path, body, headers)
     else
       @http.send(method, path, headers)


### PR DESCRIPTION
As of June 2026, [RFC 10008][] is a proposed standard.

From the RFC Abstract:

> This specification defines the QUERY method for HTTP. A QUERY requests
> that the request target process the enclosed content in a safe and
> idempotent manner and then respond with the result of that processing.
> This is similar to POST requests, but QUERY requests can be
> automatically repeated or restarted without concern for partial state
> changes.

This commit proposes support for the HTTP Query method by way of the `ActiveResource::Connection#query` method. It includes a temporary monkey-patch for the `Net::HTTP::Query` class (which may possibly be replaced by [ruby/net-http#309][] or another PR like it).

[RFC 10008]: https://www.rfc-editor.org/rfc/rfc10008.html
[ruby/net-http#309]: https://github.com/ruby/net-http/pull/309